### PR TITLE
Update routing-rules for archived schema versions

### DIFF
--- a/prod-eu-west/services/homepage/routing-rules.json
+++ b/prod-eu-west/services/homepage/routing-rules.json
@@ -1,6 +1,30 @@
 [
   {
     "Condition": {
+      "KeyPrefixEquals": "meta/kernel-2.2/index.html"
+    },
+    "Redirect": {
+      "ReplaceKeyWith": "archive/kernel-2.2/index.html"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "meta/kernel-2.1/index.html"
+    },
+    "Redirect": {
+      "ReplaceKeyWith": "archive/kernel-2.1/index.html"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "meta/kernel-2.0/index.html"
+    },
+    "Redirect": {
+      "ReplaceKeyWith": "archive/kernel-2.0/index.html"
+    }
+  },
+  {
+    "Condition": {
       "KeyPrefixEquals": "faq"
     },
     "Redirect": {

--- a/prod-eu-west/services/homepage/routing-rules.json
+++ b/prod-eu-west/services/homepage/routing-rules.json
@@ -1,6 +1,14 @@
 [
   {
     "Condition": {
+      "KeyPrefixEquals": "dc2ap"
+    },
+    "Redirect": {
+      "ReplaceKeyWith": "source/DataCite%20Dublin%20Core%20AP%20-%20Draft%201_8.pdf"
+    }
+  },
+  {
+    "Condition": {
       "KeyPrefixEquals": "meta/kernel-2.2/index.html"
     },
     "Redirect": {


### PR DESCRIPTION
adding redirects for schema versions 2.x to route from meta/kernel-2.x to archive/kernel-2.x