### PR TITLE
disable eventdata agent while we reindex events

### DIFF
--- a/prod-eu-west/services/levriero/main.tf
+++ b/prod-eu-west/services/levriero/main.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "levriero" {
   cluster = "${data.aws_ecs_cluster.default.id}"
   launch_type = "FARGATE"
   task_definition = "${aws_ecs_task_definition.levriero.arn}"
-  desired_count = 8
+  desired_count = 0
 
   network_configuration {
     security_groups = ["${data.aws_security_group.datacite-private.id}"]


### PR DESCRIPTION
to avoid conflicts, we will queue the rest of the changes