### PR TITLE
Remove signing for ES requests within the VPC

### DIFF
--- a/stage/data-storage/elasticsearch/elasticsearch_policy.json
+++ b/stage/data-storage/elasticsearch/elasticsearch_policy.json
@@ -3,7 +3,11 @@
     "Statement": [
         {
             "Action": "es:*",
-            "Principal": "*",
+            "Principal": {
+                "AWS": [
+                  "*"
+                ]
+            },
             "Effect": "Allow",
             "Resource": "arn:aws:es:eu-west-1:datacite:domain/*"
         }


### PR DESCRIPTION
This PR is for removing the requirements to do AWS request signing on ES requests.
For now only our TEST infrastructure.

Reason is to allow us to proxy via SSH locally through our bastion server (curie), this will then let us use existing tools e.g. kibana for accessing the raw ES index, this would help with debugging and development.

Note, I'm not sure the Principle set to * before was actually doing anything, the docs suggest that while a wildcard is allowed, you have to specify either accounts or IAM.