### PR TITLE
ClientAPI log level change

### DIFF
--- a/prod-eu-west/services/client-api/client-api.json
+++ b/prod-eu-west/services/client-api/client-api.json
@@ -35,7 +35,7 @@
       },
       {
         "name" : "LOG_LEVEL",
-        "value" : "warn"
+        "value" : "info"
       },
       {
         "name" : "JWT_PUBLIC_KEY",


### PR DESCRIPTION
## Purpose
Detailed logging to understand the usage of Client API 

## Approach
Client API log level changed from 'warn' to 'info'. However, we need to keep an eye on the log numbers and improve the quality of the logging



