### PR TITLE
use es-prefix in test system

### DIFF
--- a/test/services/client-api/client-api.json
+++ b/test/services/client-api/client-api.json
@@ -138,6 +138,10 @@
         "value" : "${es_name}"
       },
       {
+        "name" : "ES_PREFIX",
+        "value" : "${es_prefix}"
+      },
+      {
         "name" : "ELASTIC_PASSWORD",
         "value" : "${elastic_password}"
       },

--- a/test/services/client-api/main.tf
+++ b/test/services/client-api/main.tf
@@ -57,6 +57,7 @@ resource "aws_ecs_task_definition" "client-api-test" {
       es_host            = var.es_host
       es_scheme          = var.es_scheme
       es_port            = var.es_port
+      es_prefix          = var.es_prefix
       elastic_password   = var.elastic_password
       public_key         = var.public_key
       access_key         = var.access_key

--- a/test/services/client-api/var.tf
+++ b/test/services/client-api/var.tf
@@ -55,6 +55,9 @@ variable "es_port" {}
 variable "es_name" {
   default = "es"
 }
+variable "es_prefix" {
+  default = "sandbox"
+}
 variable "elastic_password" {}
 
 variable "security_group_id" {}


### PR DESCRIPTION
## Purpose
Use `ES_PREFIX` in test system, so that we can have multiple indexes for `client-api` in the same Elasticsearch cluster.
