### PR TITLE
use es-prefix for stage environment

### DIFF
--- a/stage/services/client-api/client-api.json
+++ b/stage/services/client-api/client-api.json
@@ -138,6 +138,10 @@
         "value" : "${es_name}"
       },
       {
+        "name" : "ES_PREFIX",
+        "value" : "${es_prefix}"
+      },
+      {
         "name" : "ELASTIC_PASSWORD",
         "value" : "${elastic_password}"
       },

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -55,6 +55,7 @@ resource "aws_ecs_task_definition" "client-api-stage" {
       es_host            = var.es_host
       es_scheme          = var.es_scheme
       es_port            = var.es_port
+      es_prefix          = var.es_prefix
       elastic_password   = var.elastic_password
       handle_url         = var.handle_url
       handle_username    = var.handle_username

--- a/stage/services/client-api/var.tf
+++ b/stage/services/client-api/var.tf
@@ -55,6 +55,9 @@ variable "es_port" {}
 variable "es_name" {
   default = "es"
 }
+variable "es_prefix" {
+  default = "sandbox"
+}
 variable "elastic_password" {}
 
 variable "security_group_id" {}


### PR DESCRIPTION
## Purpose
This allows more than one `client-api` service in one elasticsearch cluster.
