### PR TITLE
Use production containers

### DIFF
--- a/test/services/cheetoh/cheetoh.json
+++ b/test/services/cheetoh/cheetoh.json
@@ -2,8 +2,8 @@
   {
     "name": "cheetoh-test",
     "image": "datacite/cheetoh:${version}",
-    "cpu": 512,
-    "memory": 1024,
+    "cpu": 256,
+    "memory": 512,
     "essential": true,
     "networkMode": "awsvpc",
     "portMappings": [

--- a/test/services/client-api/client-api.json
+++ b/test/services/client-api/client-api.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "client-api-test",
-    "image": "datacite/lupo",
+    "image": "datacite/lupo:${version}",
     "cpu": 2048,
     "memory": 4096,
     "essential": true,

--- a/test/services/client-api/main.tf
+++ b/test/services/client-api/main.tf
@@ -71,7 +71,7 @@ resource "aws_ecs_task_definition" "client-api-test" {
       memcache_servers   = var.memcache_servers
       slack_webhook_url  = var.slack_webhook_url
       jwt_blacklisted    = var.jwt_blacklisted
-      version            = var.lupo_tags["sha"]
+      version            = var.lupo_tags["version"]
     })
 }
 

--- a/test/services/doi/doi.json
+++ b/test/services/doi/doi.json
@@ -2,7 +2,7 @@
   {
     "name": "doi-test",
     "image": "datacite/bracco:${version}",
-    "cpu": 2048,
+    "cpu": 1024,
     "memory": 4096,
     "essential": true,
     "networkMode": "awsvpc",

--- a/test/services/mds/main.tf
+++ b/test/services/mds/main.tf
@@ -41,7 +41,7 @@ resource "aws_ecs_task_definition" "mds-test" {
       api_url            = var.api_url
       realm              = var.realm
       memcache_servers   = var.memcache_servers
-      version            = var.poodle_tags["sha"]
+      version            = var.poodle_tags["version"]
     })
 }
 

--- a/test/services/mds/mds.json
+++ b/test/services/mds/mds.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "mds-test",
-    "image": "datacite/poodle",
+    "image": "datacite/poodle:${version}",
     "cpu": 256,
     "memory": 512,
     "networkMode": "awsvpc",


### PR DESCRIPTION
## Purpose
Use version-tagged containers for the production infrastructure, so that test is always in sync with production.