### PR TITLE
Increase volume size for Elasticsearch Stage

### DIFF
--- a/stage/data-storage/elasticsearch/main.tf
+++ b/stage/data-storage/elasticsearch/main.tf
@@ -17,7 +17,7 @@ resource "aws_elasticsearch_domain" "test" {
   ebs_options{
       ebs_enabled = true
       volume_type = "gp2"
-      volume_size = 60
+      volume_size = 80
   }
 
   vpc_options {


### PR DESCRIPTION
## Purpose
The Elasticsearch Cluster on stage has run out of disk space.

## Approach
Increase volume_size from 60 to 80 GB.

