### PR TITLE
Seperate elasticsearch slow search logs

### DIFF
--- a/prod-eu-west/data-storage/elasticsearch/main.tf
+++ b/prod-eu-west/data-storage/elasticsearch/main.tf
@@ -27,7 +27,7 @@ resource "aws_elasticsearch_domain" "default" {
   }
 
   log_publishing_options {
-    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.elasticsearch.arn}"
+    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.elasticsearch-slowlogs.arn}"
     log_type                 = "SEARCH_SLOW_LOGS"
   }
 
@@ -48,6 +48,10 @@ resource "aws_elasticsearch_domain_policy" "default" {
 
 resource "aws_cloudwatch_log_group" "elasticsearch" {
   name = "elasticsearch"
+}
+
+resource "aws_cloudwatch_log_group" "elasticsearch-slowlogs" {
+  name = "elasticsearch-slowlogs"
 }
 
 resource "aws_cloudwatch_log_resource_policy" "elasticsearch" {


### PR DESCRIPTION
Moves to seperate cloudwatch log group.

## Purpose

So it's easier to filter out specifically slow search queries, as there is too much log noise.
Additionally will be easier to send just these to datadog if desired.

## Approach
new cloudwatch log group.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
