### PR TITLE
add salesforce spf entry to txt record for datacite.org

### DIFF
--- a/global/dns/main.tf
+++ b/global/dns/main.tf
@@ -99,7 +99,7 @@ resource "aws_route53_record" "txt-datacite" {
     ttl = "300"
     records = [
         "${var.google_site_verification_record}",
-        "v=spf1 include:_spf.google.com ~all",
+        "v=spf1 include:_spf.google.com include:_spf.salesforce.com ~all",
         "${var.ms_record}",
         "${var.verification_record}"
     ]


### PR DESCRIPTION
## Purpose
Resolve deliverability issues for emails sent from Salesforce. A member reported that invoices sent from Salesforce are flagged as spam by their email system due to SPF validation failure. 

closes: _Add github issue that originated this PR_

## Approach
Add _spf.salesforce.com to DNS record for datacite.org as described in https://help.salesforce.com/articleView?id=emailadmin_spf_include_salesforce.htm

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
