### PR TITLE
point blog.stage to WP staging site and point oldblog.stage to current blog

### DIFF
--- a/stage/services/blog/var.tf
+++ b/stage/services/blog/var.tf
@@ -3,7 +3,7 @@ variable "secret_key" {}
 variable "region" {
     default = "eu-west-1"
 }
-
 variable "ttl" {
   default = "300"
 }
+variable "siteground_ip_stage" {}


### PR DESCRIPTION
## Purpose
Point blog.stage.datacite.org to Siteground Wordpress staging site and point new subdomain oldblog.stage.datacite.org to current Middleman blog, in preparation for blog migration.

Notes:

- Not putting blog.stage.datacite.org on Cloudfront at this point. To be done after everything is confirmed working.
- After deploying, Wordpress site URL needs to be updated in Siteground.

## Approach
- Add A record  to point blog.stage.datacite.org to Siteground per docs https://www.siteground.com/kb/point-website-domain-siteground (I don't know what they suggest A record instead of CNAME, but they do)
- Add CNAME records that point oldblog.stage.datacite.org to S3 bucket
- Update Cloudfront distribution origin and alias (origin ID doesn't _need_ to be updated, just doing so to avoid confusion)


#### Open Questions and Pre-Merge TODOs
- [x] Add Wordpress site IP to Terraform variables (located in [Siteground dashboard](https://tools.siteground.com/dashboard?siteId=S3d6K2FuZ05JQT09))

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
