### PR TITLE
Adds Search and Repository Finder redirects to Commons in stage

### DIFF
--- a/stage/services/repository-finder/input.tf
+++ b/stage/services/repository-finder/input.tf
@@ -38,3 +38,12 @@ data "aws_route53_zone" "internal" {
 data "aws_s3_bucket" "logs-stage" {
   bucket = "logs.stage.datacite.org"
 }
+
+data "aws_lb" "stage" {
+  name = "${var.lb_name}"
+}
+
+data "aws_lb_listener" "stage" {
+  load_balancer_arn = "${data.aws_lb.stage.arn}"
+  port = 443
+}

--- a/stage/services/repository-finder/main.tf
+++ b/stage/services/repository-finder/main.tf
@@ -95,7 +95,7 @@ resource "aws_lb_listener_rule" "repository-finder-stage-redirect" {
       status_code = "HTTP_301"
       host = "commons.stage.datacite.org"
       path = "/repositories"
-      query= ""
+      query = ""
     }
   }
   condition {

--- a/stage/services/repository-finder/main.tf
+++ b/stage/services/repository-finder/main.tf
@@ -83,7 +83,7 @@ resource "aws_cloudfront_distribution" "repository-finder-stage" {
 }
 
 resource "aws_lb_listener_rule" "repository-finder-stage-redirect" {
-  listener_arn = data.aws_lb_listener.stage.arn
+  listener_arn = "${data.aws_lb_listener.stage.arn}"
   priority     = 4
   
   action {
@@ -93,14 +93,15 @@ resource "aws_lb_listener_rule" "repository-finder-stage-redirect" {
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
-      host = [aws_route53_record.akita-stage.name]
+      host = "commons.stage.datacite.org"
       path = "/repositories"
+      query= ""
     }
   }
-
   condition {
-    field  = "host-header"
-    values = [aws_route53_record.repository-finder-stage.name]
+    host_header {
+      values = ["${aws_route53_record.repository-finder-stage.name}"]
+    }
   }
 }
 
@@ -109,7 +110,7 @@ resource "aws_route53_record" "repository-finder-stage" {
   name = "repositoryfinder.stage.datacite.org"
   type = "CNAME"
   ttl = "${var.ttl}"
-  records = [data.aws_lb.stage.dns_name]
+  records = ["${data.aws_lb.stage.dns_name}"]
 }
 
 resource "aws_route53_record" "split-repository-finder-stage" {
@@ -117,5 +118,5 @@ resource "aws_route53_record" "split-repository-finder-stage" {
   name = "repositoryfinder.stage.datacite.org"
   type = "CNAME"
   ttl = "${var.ttl}"
-  records = [data.aws_lb.stage.dns_name]
+  records = ["${data.aws_lb.stage.dns_name}"]
 }

--- a/stage/services/repository-finder/var.tf
+++ b/stage/services/repository-finder/var.tf
@@ -7,3 +7,7 @@ variable "region" {
 variable "ttl" {
   default = "300"
 }
+
+variable "lb_name" {
+  default = "lb-stage"
+}

--- a/stage/services/search/main.tf
+++ b/stage/services/search/main.tf
@@ -90,8 +90,15 @@ resource "aws_lb_listener_rule" "search-stage" {
   priority     = 89
 
   action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.search-stage.arn
+    type             = "redirect"
+    
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+      host = [aws_route53_record.akita-stage.name]
+      path = ""
+    }  
   }
 
   condition {

--- a/stage/services/search/main.tf
+++ b/stage/services/search/main.tf
@@ -96,7 +96,7 @@ resource "aws_lb_listener_rule" "search-stage" {
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
-      host = ["commons.stage.datacite.org"]
+      host = "commons.stage.datacite.org"
       path = ""
       query = ""
     }  

--- a/stage/services/search/main.tf
+++ b/stage/services/search/main.tf
@@ -96,8 +96,9 @@ resource "aws_lb_listener_rule" "search-stage" {
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
-      host = [aws_route53_record.akita-stage.name]
+      host = ["commons.stage.datacite.org"]
       path = ""
+      query = ""
     }  
   }
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Adds Search and Repository Finder redirects to Commons in stage to test implementation of redirects for production services. 

## Approach
<!--- _How does this change address the problem?_ -->

Changes Repository Finder Route53 records to target the load balancer and adds a load balancer listener rule to redirect repositoryfinder.stage.datacite.org requests to stage Commons. Adjusts Search load balancer listener rule to redirect to stage Commons. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
