### PR TITLE
Adds production redirects to Commons for Search and Repository Finder

### DIFF
--- a/prod-eu-west/services/repository-finder/input.tf
+++ b/prod-eu-west/services/repository-finder/input.tf
@@ -39,3 +39,12 @@ data "aws_route53_zone" "internal" {
 data "aws_s3_bucket" "logs" {
   bucket = "logs.datacite.org"
 }
+
+data "aws_lb" "default" {
+  name = "${var.lb_name}"
+}
+
+data "aws_lb_listener" "default" {
+  load_balancer_arn = "${data.aws_lb.default.arn}"
+  port = 443
+}

--- a/prod-eu-west/services/repository-finder/main.tf
+++ b/prod-eu-west/services/repository-finder/main.tf
@@ -82,12 +82,35 @@ resource "aws_cloudfront_distribution" "repository-finder" {
   }
 }
 
+resource "aws_lb_listener_rule" "repository-finder-redirect" {
+  listener_arn = "${data.aws_lb_listener.default.arn}"
+  priority     = 88
+  
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+      host = "commons.datacite.org"
+      path = "/repositories"
+      query = ""
+    }
+  }
+  condition {
+    host_header {
+      values = ["${aws_route53_record.repository-finder.name}"]
+    }
+  }
+}
+
 resource "aws_route53_record" "repository-finder" {
   zone_id = "${data.aws_route53_zone.production.zone_id}"
   name = "repositoryfinder.datacite.org"
   type = "CNAME"
   ttl = "${var.ttl}"
-  records = ["${aws_cloudfront_distribution.repository-finder.domain_name}"]
+  records = ["${data.aws_lb.default.dns_name}"] 
 }
 
 resource "aws_route53_record" "split-repository-finder" {
@@ -95,5 +118,5 @@ resource "aws_route53_record" "split-repository-finder" {
   name = "repositoryfinder.datacite.org"
   type = "CNAME"
   ttl = "${var.ttl}"
-  records = ["${aws_cloudfront_distribution.repository-finder.domain_name}"]
+  records = ["${data.aws_lb.default.dns_name}"] 
 }

--- a/prod-eu-west/services/repository-finder/var.tf
+++ b/prod-eu-west/services/repository-finder/var.tf
@@ -7,3 +7,7 @@ variable "region" {
 variable "ttl" {
   default = "300"
 }
+
+variable "lb_name" {
+  default = "lb"
+}

--- a/prod-eu-west/services/search/main.tf
+++ b/prod-eu-west/services/search/main.tf
@@ -266,8 +266,16 @@ resource "aws_lb_listener_rule" "search" {
   priority     = 89
 
   action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.search.arn
+    type             = "redirect"
+    
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+      host = "commons.datacite.org"
+      path = "/"
+      query = ""
+    }  
   }
 
   condition {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Adds Search and Repository Finder redirects to Commons. **Only to be merged after 1 June 2023**, when these services retire.

closes: datacite/datacite#1820

## Approach
<!--- _How does this change address the problem?_ -->

Changes Repository Finder Route53 records to target the load balancer and adds a load balancer listener rule to redirect repositoryfinder.datacite.org requests to Commons. Adjusts Search load balancer listener rule to redirect to Commons. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
