### PR TITLE
add dns record for homepage.stage.datacite.org

### DIFF
--- a/stage/services/homepage/input.tf
+++ b/stage/services/homepage/input.tf
@@ -2,6 +2,7 @@ provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
+  version    = "2.70"
 }
 
 provider "aws" {

--- a/stage/services/homepage/main.tf
+++ b/stage/services/homepage/main.tf
@@ -94,7 +94,7 @@ resource "aws_route53_record" "split-www-stage" {
    records = ["${aws_cloudfront_distribution.www-stage.domain_name}"]
 }
 
-// Temp A records to point a domain to Wordpress staging site
+// Temp A records to point homepage.stage.datacite.org domain to Wordpress staging site in Siteground
 // Using A record rather than CNAME per https://www.siteground.com/kb/point-website-domain-siteground
 resource "aws_route53_record" "wp-stage" {
    zone_id = "${data.aws_route53_zone.production.zone_id}"

--- a/stage/services/homepage/main.tf
+++ b/stage/services/homepage/main.tf
@@ -93,3 +93,21 @@ resource "aws_route53_record" "split-www-stage" {
    ttl = "${var.ttl}"
    records = ["${aws_cloudfront_distribution.www-stage.domain_name}"]
 }
+
+// Temp A records to point a domain to Wordpress staging site
+// Using A record rather than CNAME per https://www.siteground.com/kb/point-website-domain-siteground
+resource "aws_route53_record" "wp-stage" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "homepage.stage.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_stage}"]
+}
+
+resource "aws_route53_record" "wp-stage-wildcard" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "*.homepage.stage.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_stage}"]
+}

--- a/stage/services/homepage/var.tf
+++ b/stage/services/homepage/var.tf
@@ -7,3 +7,5 @@ variable "region" {
 variable "ttl" {
   default = "300"
 }
+
+variable "siteground_ip_homepage_stage" {}


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
In preparation for migrating the homepage site (datacite.org) from Middleman hosted on S3 to Wordpress hosted on Siteground, the Siteground staging site needs a domain. 

## Approach
<!--- _How does this change address the problem?_ -->
Added A record to point new subdomain homepage.stage.datacite.org to Siteground staging site IP address.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ X] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
