### PR TITLE
DNS for Siteground staging copy

### DIFF
--- a/prod-eu-west/services/homepage/main.tf
+++ b/prod-eu-west/services/homepage/main.tf
@@ -109,3 +109,11 @@ resource "aws_route53_record" "wp-prod" {
    ttl = "${var.ttl}"
    records = ["${var.siteground_ip_homepage_prod}"]
 }
+
+resource "aws_route53_record" "wp-prod-staging-copies" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "staging*.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_prod}"]
+}

--- a/prod-eu-west/services/homepage/main.tf
+++ b/prod-eu-west/services/homepage/main.tf
@@ -112,7 +112,7 @@ resource "aws_route53_record" "wp-prod" {
 
 resource "aws_route53_record" "wp-prod-staging-copies" {
    zone_id = "${data.aws_route53_zone.production.zone_id}"
-   name = "staging*.datacite.org"
+   name = "staging2.datacite.org"
    type = "A"
    ttl = "${var.ttl}"
    records = ["${var.siteground_ip_homepage_prod}"]


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Siteground supports a "staging copy" feature, which generates a temp copy of a live site for development purposes. A new subdomain is automatically created for each temp copy, formatted like staging2.datacite.org, but it does not have any DNS records unless the parent domain is managed by Siteground.

## Approach
<!--- _How does this change address the problem?_ -->

Add DNS A record for staging2.datacite.org that points to Siteground

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
