### PR TITLE
add dns for staging copies 3-10

### DIFF
--- a/prod-eu-west/services/homepage/main.tf
+++ b/prod-eu-west/services/homepage/main.tf
@@ -110,9 +110,65 @@ resource "aws_route53_record" "wp-prod" {
    records = ["${var.siteground_ip_homepage_prod}"]
 }
 
-resource "aws_route53_record" "wp-prod-staging-copies" {
+resource "aws_route53_record" "wp-prod-staging-copy-3" {
    zone_id = "${data.aws_route53_zone.production.zone_id}"
-   name = "staging2.datacite.org"
+   name = "staging3.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_prod}"]
+}
+
+resource "aws_route53_record" "wp-prod-staging-copy-4" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "staging4.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_prod}"]
+}
+
+resource "aws_route53_record" "wp-prod-staging-copy-5" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "staging5.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_prod}"]
+}
+
+resource "aws_route53_record" "wp-prod-staging-copy-6" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "staging6.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_prod}"]
+}
+
+resource "aws_route53_record" "wp-prod-staging-copy-7" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "staging7.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_prod}"]
+}
+
+resource "aws_route53_record" "wp-prod-staging-copy-8" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "staging8.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_prod}"]
+}
+
+resource "aws_route53_record" "wp-prod-staging-copy-9" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "staging9.datacite.org"
+   type = "A"
+   ttl = "${var.ttl}"
+   records = ["${var.siteground_ip_homepage_prod}"]
+}
+
+resource "aws_route53_record" "wp-prod-staging-copy-10" {
+   zone_id = "${data.aws_route53_zone.production.zone_id}"
+   name = "staging10.datacite.org"
    type = "A"
    ttl = "${var.ttl}"
    records = ["${var.siteground_ip_homepage_prod}"]


### PR DESCRIPTION
## Purpose
Siteground allows creating unlimited staging copies of the Wordpress homepage site, each with domains like stagingX.datacite.org where the number in the domain is incremented by 1 for each subsequent staging copy. Staging need DNS records pointing to our Siteground IP in order to make them reachable.

## Approach
Pre-emptively create DNS records for staging3.datacite.org through staging10.datacite.org, so that they are reachable on creation by the engagement team.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
