### PR TITLE
Use combined metrics for alarm thresholds

### DIFF
--- a/prod-eu-west/services/client-api/queue-worker.tf
+++ b/prod-eu-west/services/client-api/queue-worker.tf
@@ -135,137 +135,138 @@ resource "aws_appautoscaling_policy" "queue-worker_scale_down" {
   }
 }
 
-// Cloudwatch metric alarm for scaling up based on SQS queue size production_lupo
-resource "aws_cloudwatch_metric_alarm" "queue_worker_production_lupo_scale_up_alarm" {
-  alarm_name          = "queue-worker_request_scale_up"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "ApproximateNumberOfMessagesVisible"
-  dimensions = {
-    QueueName = "production_lupo"
-  }
-  namespace           = "AWS/SQS"
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = "60000"
-  alarm_description   = "This metric monitors queue-worker queue size for production_lupo"
-  alarm_actions       = [aws_appautoscaling_policy.queue-worker_scale_up.arn]
-}
-
-// Cloudwatch metric alarm for scaling down based on SQS queue size production_lupo
-resource "aws_cloudwatch_metric_alarm" "queue_worker_production_lupo_scale_down_alarm" {
-  alarm_name          = "queue-worker_request_scale_down"
-  comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "ApproximateNumberOfMessagesVisible"
-  dimensions = {
-    QueueName = "production_lupo"
-  }
-  namespace           = "AWS/SQS"
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = "10000"
-  alarm_description   = "This metric monitors queue-worker queue size for production_lupo"
-  alarm_actions       = [aws_appautoscaling_policy.queue-worker_scale_down.arn]
-}
-
-// Need to upgrade AWS provider version to use this
-# // Cloudwatch metric alarm for scaling up based on SQS queue size
-# resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_up_alarm" {
-#   alarm_name          = "queue_worker_scale_up_alarm"
+# // Cloudwatch metric alarm for scaling up based on SQS queue size production_lupo
+# resource "aws_cloudwatch_metric_alarm" "queue_worker_production_lupo_scale_up_alarm" {
+#   alarm_name          = "queue-worker_request_scale_up"
 #   comparison_operator = "GreaterThanOrEqualToThreshold"
 #   evaluation_periods  = "1"
-#   alarm_description   = "This metric monitors queue-worker queue size"
+#   metric_name         = "ApproximateNumberOfMessagesVisible"
+#   dimensions = {
+#     QueueName = "production_lupo"
+#   }
+#   namespace           = "AWS/SQS"
+#   period              = "60"
+#   statistic           = "Sum"
+#   threshold           = "60000"
+#   alarm_description   = "This metric monitors queue-worker queue size for production_lupo"
 #   alarm_actions       = [aws_appautoscaling_policy.queue-worker_scale_up.arn]
-
-#   threshold           = "100000"
-
-#   // Custom query that sums the two other metrics
-#   metric_query {
-#     id          = "total_visible"
-#     expression  = "production_visible + production_background_visible"
-#     label       = "Total visible messages"
-#     return_data = "true"
-#   }
-
-#   metric_query {
-#     id = "production_visible"
-
-#     metric {
-#       metric_name = "ApproximateNumberOfMessagesVisible"
-#       namespace   = "AWS/SQS"
-#       period      = "60"
-#       stat        = "Maximum"
-
-#       dimensions {
-#         QueueName = "production_lupo"
-#       }
-#     }
-#   }
-
-#   metric_query {
-#     id = "production_background_visible"
-
-#     metric {
-#       metric_name = "ApproximateNumberOfMessagesVisible"
-#       namespace   = "AWS/SQS"
-#       period      = "60"
-#       stat        = "Maximum"
-
-#       dimensions {
-#         QueueName = "production_lupo_background"
-#       }
-#     }
-#   }
-
 # }
 
-# // Cloudwatch metric alarm for scaling down based on SQS queue size
-# resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_down_alarm" {
-#   alarm_name          = "queue_worker_scale_down_alarm"
+# // Cloudwatch metric alarm for scaling down based on SQS queue size production_lupo
+# resource "aws_cloudwatch_metric_alarm" "queue_worker_production_lupo_scale_down_alarm" {
+#   alarm_name          = "queue-worker_request_scale_down"
 #   comparison_operator = "LessThanOrEqualToThreshold"
 #   evaluation_periods  = "1"
-#   alarm_description   = "This metric monitors queue-worker queue size"
-#   alarm_actions       = [aws_appautoscaling_policy.queue-worker_scale_down.arn]
-
+#   metric_name         = "ApproximateNumberOfMessagesVisible"
+#   dimensions = {
+#     QueueName = "production_lupo"
+#   }
+#   namespace           = "AWS/SQS"
+#   period              = "60"
+#   statistic           = "Sum"
 #   threshold           = "10000"
-
-#   // Custom query that sums the two other metrics
-#   metric_query {
-#     id          = "total_visible"
-#     expression  = "production_visible + production_background_visible"
-#     label       = "Total visible messages"
-#     return_data = "true"
-#   }
-
-#   metric_query {
-#     id = "production_visible"
-
-#     metric {
-#       metric_name = "ApproximateNumberOfMessagesVisible"
-#       namespace   = "AWS/SQS"
-#       period      = "60"
-#       stat        = "Maximum"
-
-#       dimensions {
-#         QueueName = "production_lupo"
-#       }
-#     }
-#   }
-
-#   metric_query {
-#     id = "production_background_visible"
-
-#     metric {
-#       metric_name = "ApproximateNumberOfMessagesVisible"
-#       namespace   = "AWS/SQS"
-#       period      = "60"
-#       stat        = "Maximum"
-
-#       dimensions {
-#         QueueName = "production_lupo_background"
-#       }
-#     }
-#   }
-
+#   alarm_description   = "This metric monitors queue-worker queue size for production_lupo"
+#   alarm_actions       = [aws_appautoscaling_policy.queue-worker_scale_down.arn]
 # }
+
+// Cloudwatch metric alarm for scaling up based on SQS queue size
+resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_up_alarm" {
+  alarm_name          = "queue_worker_scale_up_alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  alarm_description   = "This metric monitors queue-worker queue size"
+  alarm_actions       = [aws_appautoscaling_policy.queue-worker_scale_up.arn]
+
+  threshold           = "100000"
+
+  // Custom query that sums the two other metrics
+  metric_query {
+    id          = "total_visible"
+    expression  = "production_visible + production_background_visible"
+    label       = "Total visible messages"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "production_visible"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_lupo"
+      }
+    }
+  }
+
+  metric_query {
+    id = "production_background_visible"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_lupo_background"
+      }
+    }
+  }
+
+}
+
+// Cloudwatch metric alarm for scaling down based on SQS queue size
+resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_down_alarm" {
+  alarm_name          = "queue_worker_scale_down_alarm"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  // Evalulation period should be greater than the scale-up evalulation period
+  // scale up quickly but scale down slowly to avoid potential thrashing of up/down periods
+  evaluation_periods  = "2"
+  alarm_description   = "This metric monitors queue-worker queue size"
+  alarm_actions       = [aws_appautoscaling_policy.queue-worker_scale_down.arn]
+
+  threshold           = "10000"
+
+  // Custom query that sums the two other metrics
+  metric_query {
+    id          = "total_visible"
+    expression  = "production_visible + production_background_visible"
+    label       = "Total visible messages"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "production_visible"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_lupo"
+      }
+    }
+  }
+
+  metric_query {
+    id = "production_background_visible"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_lupo_background"
+      }
+    }
+  }
+
+}

--- a/prod-eu-west/services/client-api/queue-worker.tf
+++ b/prod-eu-west/services/client-api/queue-worker.tf
@@ -180,6 +180,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_up_alarm" {
   threshold           = "100000"
 
   // Custom query that sums the two other metrics
+  // This is the value that will be compared to the threshold
   metric_query {
     id          = "total_visible"
     expression  = "production_visible + production_background_visible"


### PR DESCRIPTION
This uses metric_queries to aggregate lupo and lupo_background queues and then base the alarm on this.

Period is 2 minutes with an evaluation period of once every 2 minutes for scaling up and once every 4 minutes for scaling down.

## Purpose
Improve queue scaling 
closes: datacite/datacite#2070

## Approach
Allows watching over the two most important queues.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
