### PR TITLE
Switch client-api code to use api specific access key

### DIFF
--- a/prod-eu-west/services/client-api/main.tf
+++ b/prod-eu-west/services/client-api/main.tf
@@ -221,8 +221,8 @@ resource "aws_ecs_task_definition" "client-api" {
       es_name            = var.es_name
       es_host            = var.es_host
       public_key         = var.public_key
-      access_key         = var.access_key
-      secret_key         = var.secret_key
+      access_key         = var.api_aws_access_key
+      secret_key         = var.api_aws_secret_key
       region             = var.region
       s3_bucket          = var.s3_bucket
       admin_username     = var.admin_username

--- a/prod-eu-west/services/client-api/member.tf
+++ b/prod-eu-west/services/client-api/member.tf
@@ -186,8 +186,8 @@ resource "aws_ecs_task_definition" "member-api" {
       es_name            = var.es_name
       es_host            = var.es_host
       public_key         = var.public_key
-      access_key         = var.access_key
-      secret_key         = var.secret_key
+      access_key         = var.api_aws_access_key
+      secret_key         = var.api_aws_secret_key
       region             = var.region
       s3_bucket          = var.s3_bucket
       admin_username     = var.admin_username

--- a/prod-eu-west/services/client-api/migration.tf
+++ b/prod-eu-west/services/client-api/migration.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "migration-api" {
   cluster = data.aws_ecs_cluster.default.id
   launch_type = "FARGATE"
   task_definition = aws_ecs_task_definition.migration-api.arn
-  
+
   # Create service with 1 instance
   desired_count = 0
 
@@ -49,8 +49,8 @@ resource "aws_ecs_task_definition" "migration-api" {
       es_name            = var.es_name
       es_host            = var.es_host
       public_key         = var.public_key
-      access_key         = var.access_key
-      secret_key         = var.secret_key
+      access_key         = var.api_aws_access_key
+      secret_key         = var.api_aws_secret_key
       region             = var.region
       s3_bucket          = var.s3_bucket
       admin_username     = var.admin_username

--- a/prod-eu-west/services/client-api/queue-worker.tf
+++ b/prod-eu-west/services/client-api/queue-worker.tf
@@ -53,8 +53,8 @@ resource "aws_ecs_task_definition" "queue-worker" {
       es_name            = var.es_name
       es_host            = var.es_host
       public_key         = var.public_key
-      access_key         = var.access_key
-      secret_key         = var.secret_key
+      access_key         = var.api_aws_access_key
+      secret_key         = var.api_aws_secret_key
       region             = var.region
       s3_bucket          = var.s3_bucket
       admin_username     = var.admin_username

--- a/prod-eu-west/services/client-api/var.tf
+++ b/prod-eu-west/services/client-api/var.tf
@@ -74,3 +74,6 @@ variable "namespace_id" {}
 variable "jwt_blacklisted" {}
 variable "plugin_openapi_url" {}
 variable "plugin_manifest_url" {}
+
+variable "api_aws_access_key" {}
+variable "api_aws_secret_key" {}

--- a/prod-eu-west/services/profiles/var.tf
+++ b/prod-eu-west/services/profiles/var.tf
@@ -90,3 +90,6 @@ variable "es_host" {
 variable "es_name" {
   default = "es"
 }
+
+variable "api_aws_access_key" {}
+variable "api_aws_secret_key" {}

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "client-api-stage" {
   cluster = data.aws_ecs_cluster.stage.id
   launch_type = "FARGATE"
   task_definition = aws_ecs_task_definition.client-api-stage.arn
-  desired_count = 1
+  desired_count = 2
 
   network_configuration {
     security_groups = [data.aws_security_group.datacite-private.id]
@@ -62,8 +62,8 @@ resource "aws_ecs_task_definition" "client-api-stage" {
       handle_password    = var.handle_password
       admin_username     = var.admin_username
       admin_password     = var.admin_password
-      access_key         = var.access_key
-      secret_key         = var.secret_key
+      access_key         = var.api_aws_access_key
+      secret_key         = var.api_aws_secret_key
       region             = var.region
       s3_bucket          = var.s3_bucket
       sentry_dsn         = var.sentry_dsn

--- a/stage/services/client-api/queue-worker.tf
+++ b/stage/services/client-api/queue-worker.tf
@@ -53,8 +53,8 @@ resource "aws_ecs_task_definition" "queue-worker-stage" {
       handle_password    = var.handle_password
       admin_username     = var.admin_username
       admin_password     = var.admin_password
-      access_key         = var.access_key
-      secret_key         = var.secret_key
+      access_key         = var.api_aws_access_key
+      secret_key         = var.api_aws_secret_key
       region             = var.region
       s3_bucket          = var.s3_bucket
       sentry_dsn         = var.sentry_dsn

--- a/stage/services/client-api/var.tf
+++ b/stage/services/client-api/var.tf
@@ -79,3 +79,6 @@ variable "oidc_client_secret" {}
 variable "jwt_blacklisted" {}
 variable "plugin_openapi_url" {}
 variable "plugin_manifest_url" {}
+
+variable "api_aws_access_key" {}
+variable "api_aws_secret_key" {}

--- a/test/services/client-api/main.tf
+++ b/test/services/client-api/main.tf
@@ -60,8 +60,8 @@ resource "aws_ecs_task_definition" "client-api-test" {
       es_prefix          = var.es_prefix
       elastic_password   = var.elastic_password
       public_key         = var.public_key
-      access_key         = var.access_key
-      secret_key         = var.secret_key
+      access_key         = var.api_aws_access_key
+      secret_key         = var.api_aws_secret_key
       region             = var.region
       s3_bucket          = var.s3_bucket
       admin_username     = var.admin_username

--- a/test/services/client-api/queue-worker.tf
+++ b/test/services/client-api/queue-worker.tf
@@ -53,8 +53,8 @@ resource "aws_ecs_task_definition" "queue-worker-test" {
       handle_password    = var.handle_password
       admin_username     = var.admin_username
       admin_password     = var.admin_password
-      access_key         = var.access_key
-      secret_key         = var.secret_key
+      access_key         = var.api_aws_access_key
+      secret_key         = var.api_aws_secret_key
       region             = var.region
       s3_bucket          = var.s3_bucket
       sentry_dsn         = var.sentry_dsn

--- a/test/services/client-api/var.tf
+++ b/test/services/client-api/var.tf
@@ -83,3 +83,6 @@ variable "plugin_openapi_url" {
 variable "plugin_manifest_url" {
   default = "https://api.test.datacite.org"
 }
+
+variable "api_aws_access_key" {}
+variable "api_aws_secret_key" {}


### PR DESCRIPTION
## Purpose
To avoid reusing the terraform aws key also within the application.

## Approach
Define a specific new variable for a different aws key.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
