### PR TITLE
point corpus.stage to ALB instead of EC2 instance

### DIFF
--- a/global/dns/main.tf
+++ b/global/dns/main.tf
@@ -167,7 +167,7 @@ resource "aws_route53_record" "corpus-prototype-staging" {
     name = "corpus.stage.datacite.org"
     type = "A"
     ttl = "300"
-    records = ["99.80.53.232"]
+    records = ["corpus-stage-543312680.eu-west-1.elb.amazonaws.com"]
 }
 
 // Data citation corpus prod


### PR DESCRIPTION
## Purpose
Point corpus.stage.datacite.org to ALB instead of directly to EC2 instance

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
