### PR TITLE
add ssl validation for corpus prod and point corpus.datacite.org to LB

### DIFF
--- a/global/dns/main.tf
+++ b/global/dns/main.tf
@@ -180,13 +180,23 @@ resource "aws_route53_record" "corpus-prototype-staging-ssl-validation" {
 
 }
 
+
 // Data citation corpus prod
 resource "aws_route53_record" "corpus-prototype-prod" {
     zone_id = aws_route53_zone.production.zone_id
     name = "corpus.datacite.org"
-    type = "A"
+    type = "CNAME"
     ttl = "300"
-    records = ["54.229.227.84"]
+    records = ["corpus-prod-1654713238.eu-west-1.elb.amazonaws.com"]
+}
+
+resource "aws_route53_record" "corpus-prototype-prod-ssl-validation" {
+    zone_id = aws_route53_zone.production.zone_id
+    name = "_a20336933a30c9ce94e198bf89da2260.corpus.datacite.org."
+    type = "CNAME"
+    ttl = "86400"
+    records = ["_127c9ef2a9ac28dbdc3964ffc97860a6.djqtsrsxkq.acm-validations.aws."]
+
 }
 
 // Google DataCite dns entries


### PR DESCRIPTION
## Purpose
Corpus prod DNS updates: add CNAME record for SSL validation, point corpus.datacite.org to load balancer instead of IP

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
