### PR TITLE
Add doi_registration queue to queue worker alarm config

### DIFF
--- a/prod-eu-west/services/client-api/queue-worker.tf
+++ b/prod-eu-west/services/client-api/queue-worker.tf
@@ -150,7 +150,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_up_alarm" {
   // This is the value that will be compared to the threshold
   metric_query {
     id          = "total_visible"
-    expression  = "production_visible + production_background_visible"
+    expression  = "production_visible + production_background_visible + production_registration_visible"
     label       = "Total visible messages"
     return_data = "true"
   }
@@ -181,6 +181,21 @@ resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_up_alarm" {
 
       dimensions = {
         QueueName = "production_lupo_background"
+      }
+    }
+  }
+
+  metric_query {
+    id = "production_registration_visible"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_lupo_doi_registration"
       }
     }
   }
@@ -202,7 +217,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_down_alarm" {
   // Custom query that sums the two other metrics
   metric_query {
     id          = "total_visible"
-    expression  = "production_visible + production_background_visible"
+    expression  = "production_visible + production_background_visible + production_registration_visible"
     label       = "Total visible messages"
     return_data = "true"
   }
@@ -233,6 +248,21 @@ resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_down_alarm" {
 
       dimensions = {
         QueueName = "production_lupo_background"
+      }
+    }
+  }
+
+  metric_query {
+    id = "production_registration_visible"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_lupo_doi_registration"
       }
     }
   }


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Add the new doi_registration queue to the autoscaling alarm config, to ensure that worker scaling happens for all lupo queues.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
