### PR TITLE
Remove unused plugin env vars from stage config

### DIFF
--- a/stage/services/client-api/client-api.json
+++ b/stage/services/client-api/client-api.json
@@ -170,14 +170,6 @@
         "value": "${sha}"
       },
       {
-        "name": "PLUGIN_MANIFEST_URL",
-        "value": "${plugin_manifest_url}"
-      },
-      {
-        "name": "PLUGIN_OPENAPI_URL",
-        "value": "${plugin_openapi_url}"
-      },
-      {
         "name": "DISABLE_QUEUE_WORKER",
         "value": "True"
       },

--- a/stage/services/client-api/queue-worker.json
+++ b/stage/services/client-api/queue-worker.json
@@ -170,14 +170,6 @@
         "value": "${sha}"
       },
       {
-        "name": "PLUGIN_MANIFEST_URL",
-        "value": "${plugin_manifest_url}"
-      },
-      {
-        "name": "PLUGIN_OPENAPI_URL",
-        "value": "${plugin_openapi_url}"
-      },
-      {
         "name": "SQS_PREFIX",
         "value": "stage"
       },


### PR DESCRIPTION
## Purpose
Removes unnecessary plugin-related environment variables from the stage environment configuration for the client-api and its queue-worker.

## Approach
This change addresses the problem by removing the `PLUGIN_MANIFEST_URL` and `PLUGIN_OPENAPI_URL` environment variables from the respective service configuration files in the `stage` directory. These variables were not being used or were configured elsewhere for these services in this environment.

### Key Modifications

*   Removed `PLUGIN_MANIFEST_URL` and `PLUGIN_OPENAPI_URL` environment variables from `stage/services/client-api/client-api.json`.
*   Removed `PLUGIN_MANIFEST_URL` and `PLUGIN_OPENAPI_URL` environment variables from `stage/services/client-api/queue-worker.json`.

### Important Technical Details

The changes involve modifying the environment variable lists within the task definition configuration files (`.json`) for the client-api service and its associated queue worker in the `stage` environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue, e.g., removing unused configuration)


- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
