### PR TITLE
Remove unused plugin env vars from test and prod config

### DIFF
--- a/prod-eu-west/services/client-api/client-api.json
+++ b/prod-eu-west/services/client-api/client-api.json
@@ -155,14 +155,6 @@
         "value": "${slack_webhook_url}"
       },
       {
-        "name": "PLUGIN_MANIFEST_URL",
-        "value": "${plugin_manifest_url}"
-      },
-      {
-        "name": "PLUGIN_OPENAPI_URL",
-        "value": "${plugin_openapi_url}"
-      },
-      {
         "name": "DISABLE_QUEUE_WORKER",
         "value": "True"
       },

--- a/prod-eu-west/services/client-api/queue-worker.json
+++ b/prod-eu-west/services/client-api/queue-worker.json
@@ -150,14 +150,6 @@
         "value": "${slack_webhook_url}"
       },
       {
-        "name": "PLUGIN_MANIFEST_URL",
-        "value": "${plugin_manifest_url}"
-      },
-      {
-        "name": "PLUGIN_OPENAPI_URL",
-        "value": "${plugin_openapi_url}"
-      },
-      {
         "name": "EXCLUDE_PREFIXES_FROM_DATA_IMPORT",
         "value": "${exclude_prefixes_from_data_import}"
       }

--- a/stage/services/client-api/client-api.json
+++ b/stage/services/client-api/client-api.json
@@ -170,14 +170,6 @@
         "value": "${sha}"
       },
       {
-        "name": "PLUGIN_MANIFEST_URL",
-        "value": "${plugin_manifest_url}"
-      },
-      {
-        "name": "PLUGIN_OPENAPI_URL",
-        "value": "${plugin_openapi_url}"
-      },
-      {
         "name": "DISABLE_QUEUE_WORKER",
         "value": "True"
       },

--- a/stage/services/client-api/queue-worker.json
+++ b/stage/services/client-api/queue-worker.json
@@ -170,14 +170,6 @@
         "value": "${sha}"
       },
       {
-        "name": "PLUGIN_MANIFEST_URL",
-        "value": "${plugin_manifest_url}"
-      },
-      {
-        "name": "PLUGIN_OPENAPI_URL",
-        "value": "${plugin_openapi_url}"
-      },
-      {
         "name": "SQS_PREFIX",
         "value": "stage"
       },

--- a/test/services/client-api/queue-worker.json
+++ b/test/services/client-api/queue-worker.json
@@ -170,14 +170,6 @@
         "value": "${sha}"
       },
       {
-        "name": "PLUGIN_MANIFEST_URL",
-        "value": "${plugin_manifest_url}"
-      },
-      {
-        "name": "PLUGIN_OPENAPI_URL",
-        "value": "${plugin_openapi_url}"
-      },
-      {
         "name": "SQS_PREFIX",
         "value": "test"
       }


### PR DESCRIPTION
## Purpose
This PR removes environment variables that are no longer used by the client-api service and its queue worker.

## Approach
The environment variables `PLUGIN_MANIFEST_URL` and `PLUGIN_OPENAPI_URL` were identified as unused in the current codebase for the client-api service. This change removes these variables from the service configurations across the `prod-eu-west`, `stage`, and `test` environments to clean up the configuration files.

### Key Modifications
- Removed the `PLUGIN_MANIFEST_URL` environment variable from:
    - `prod-eu-west/services/client-api/client-api.json`
    - `prod-eu-west/services/client-api/queue-worker.json`
    - `stage/services/client-api/client-api.json`
    - `stage/services/client-api/queue-worker.json`
    - `test/services/client-api/queue-worker.json`
- Removed the `PLUGIN_OPENAPI_URL` environment variable from the same files listed above.

### Important Technical Details
The removal of these variables is a straightforward cleanup and has no functional impact on the service, as the code paths that would utilize these variables are not active or relevant anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue - in this case, an unnecessary configuration)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
