### PR TITLE
Add OtherDoi batch enqueue queue

### DIFF
--- a/modules/datacite_queues/main.tf
+++ b/modules/datacite_queues/main.tf
@@ -66,6 +66,20 @@ resource "aws_sqs_queue" "lupo_import" {
   }
 }
 
+resource "aws_sqs_queue" "lupo_queue_batches_other_doi" {
+  name = "${var.environment}_lupo_queue_batches_other_doi"
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.queue_batches_other_doi-dead-letter.arn
+    maxReceiveCount     = 4
+  }) 
+  visibility_timeout_seconds = 300
+  tags                       = var.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_sqs_queue" "lupo_import_other_doi" {
   name = "${var.environment}_lupo_import_other_doi"
   redrive_policy = jsonencode({
@@ -223,6 +237,16 @@ resource "aws_sqs_queue" "events_index" {
   }
 }
 
+// BatchQueing dead letter queue
+resource "aws_sqs_queue" "queue_batches_other_doi-dead-letter" {
+  name = "${var.environment}_queue_batches_other_doi-dead-letter"
+
+  tags = var.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 // Shared dead letter queue
 resource "aws_sqs_queue" "dead-letter" {
   name = "${var.environment}_dead-letter"


### PR DESCRIPTION
## Purpose
This PR introduces a new SQS queue, `lupo_queue_batches_other_doi`, and its corresponding dead-letter queue, `queue_batches_other_doi-dead-letter`. This new queue is intended to handle the batch processing of DOIs that are not DataCite DOIs.

## Approach
This change addresses the need for a dedicated queue to manage batch operations for "other" DOIs by provisioning the required SQS resources in the `datacite_queues` module.

### Key Modifications
*   **Added `lupo_queue_batches_other_doi` SQS Queue:** A new AWS SQS queue is created with a `redrive_policy` pointing to its dedicated dead-letter queue and a `visibility_timeout_seconds` of 300.
*   **Added `queue_batches_other_doi-dead-letter` SQS Queue:** A new AWS SQS queue is created to serve as the dead-letter queue for `lupo_queue_batches_other_doi`.
*   **Prevent Destroy Lifecycle Block:** Both new queues include a `prevent_destroy = true` lifecycle rule to prevent accidental deletion.

### Important Technical Details
*   The `lupo_queue_batches_other_doi` queue's name will be prefixed with the environment (e.g., `production_lupo_queue_batches_other_doi`).
*   The `maxReceiveCount` for the redrive policy is set to 4, meaning a message will be moved to the dead-letter queue after 4 failed attempts to process it.
*   The `visibility_timeout_seconds` is set to 300 seconds (5 minutes) for the `lupo_queue_batches_other_doi`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)


- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
