### PR TITLE
Shoryuken concurrency configuration to queue workers in prod and test

### DIFF
--- a/prod-eu-west/services/client-api/queue-worker.json
+++ b/prod-eu-west/services/client-api/queue-worker.json
@@ -152,6 +152,14 @@
       {
         "name": "EXCLUDE_PREFIXES_FROM_DATA_IMPORT",
         "value": "${exclude_prefixes_from_data_import}"
+      },
+      {
+        "name": "SHORYUKEN_CONCURRENCY",
+        "value": "${shoryuken_concurrency}"
+      },
+      {
+        "name": "CONCURRENCY",
+        "value": "${shoryuken_concurrency}"
       }
     ]
   }

--- a/prod-eu-west/services/client-api/queue-worker.tf
+++ b/prod-eu-west/services/client-api/queue-worker.tf
@@ -66,6 +66,7 @@ resource "aws_ecs_task_definition" "queue-worker" {
       jwt_blacklisted                   = var.jwt_blacklisted
       version                           = var.lupo_tags["version"]
       exclude_prefixes_from_data_import = var.exclude_prefixes_from_data_import
+      shoryuken_concurrency             = var.shoryuken_concurrency
   })
 }
 

--- a/prod-eu-west/services/client-api/var.tf
+++ b/prod-eu-west/services/client-api/var.tf
@@ -79,3 +79,6 @@ variable "api_aws_secret_key" {}
 variable "exclude_prefixes_from_data_import" {
   default = ""
 }
+variable "shoryuken_concurrency" {
+  default = "30"
+}

--- a/test/services/client-api/queue-worker.json
+++ b/test/services/client-api/queue-worker.json
@@ -172,6 +172,14 @@
       {
         "name": "SQS_PREFIX",
         "value": "test"
+      },
+      {
+        "name": "SHORYUKEN_CONCURRENCY",
+        "value": "${shoryuken_concurrency}"
+      },
+      {
+        "name": "CONCURRENCY",
+        "value": "${shoryuken_concurrency}"
       }
     ]
   }

--- a/test/services/client-api/queue-worker.tf
+++ b/test/services/client-api/queue-worker.tf
@@ -64,6 +64,7 @@ resource "aws_ecs_task_definition" "queue-worker-test" {
       slack_webhook_url             = var.slack_webhook_url
       version                       = var.lupo_tags["version"]
       sha                           = var.lupo_tags["sha"]
+      shoryuken_concurrency         = var.shoryuken_concurrency
   })
 }
 

--- a/test/services/client-api/var.tf
+++ b/test/services/client-api/var.tf
@@ -80,3 +80,6 @@ variable "jwt_blacklisted" {}
 
 variable "api_aws_access_key" {}
 variable "api_aws_secret_key" {}
+variable "shoryuken_concurrency" {
+  default = "30"
+}


### PR DESCRIPTION
## Purpose
This PR introduces a new configurable environment variable, `SHORYUKEN_CONCURRENCY`, to manage the concurrency level of the Shoryuken queue worker. This allows for dynamic adjustment of how many jobs Shoryuken processes simultaneously, which can be crucial for performance tuning and resource management.

## Approach
The changes enable the `SHORYUKEN_CONCURRENCY` and `CONCURRENCY` environment variables to be set for the `queue-worker` service in both `prod-eu-west` and `test` environments. This is achieved by introducing a new Terraform variable `shoryuken_concurrency` with a default value of "30". This variable is then passed as an environment variable to the ECS task definition.

### Key Modifications
- **Added `SHORYUKEN_CONCURRENCY` and `CONCURRENCY` environment variables**: These are added to the `containerDefinitions` block in `queue-worker.json` for both `prod-eu-west` and `test` environments.
- **Introduced `shoryuken_concurrency` Terraform variable**: A new variable `shoryuken_concurrency` is added to `var.tf` in both environments, with a `default` value of "30".
- **Passed `shoryuken_concurrency` to template_file**: The `shoryuken_concurrency` variable is now included in the `vars` block of the `template_file` resource in `queue-worker.tf`, allowing its value to be rendered into the `queue-worker.json` configuration.

### Important Technical Details
- The `CONCURRENCY` environment variable is also set to the value of `shoryuken_concurrency` for backward compatibility or potential alternative uses by Shoryuken.
- The `default` value of "30" for `shoryuken_concurrency` provides a sensible initial concurrency level, which can be overridden as needed per environment.
- This change provides more fine-grained control over the queue worker's behavior in response to changes in load or resource availability.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
