### PR TITLE
Include import SQS queues in scaling queue workers

### DIFF
--- a/prod-eu-west/services/client-api/queue-worker.tf
+++ b/prod-eu-west/services/client-api/queue-worker.tf
@@ -149,10 +149,41 @@ resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_up_alarm" {
   // This is the value that will be compared to the threshold
   metric_query {
     id          = "total_visible"
-    expression  = "production_visible + production_background_visible + production_registration_visible"
+    expression  = "production_visible + production_background_visible + production_registration_visible + production_import_datacite_doi + production_import_other_doi"
     label       = "Total visible messages"
     return_data = "true"
   }
+
+  metric_query {
+    id = "production_import_datacite_doi"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_import"
+      }
+    }
+  }
+
+  metric_query {
+    id = "production_import_other_doi"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_import_other_doi"
+      }
+    }
+  }
+
 
   metric_query {
     id = "production_visible"
@@ -216,9 +247,39 @@ resource "aws_cloudwatch_metric_alarm" "queue_worker_scale_down_alarm" {
   // Custom query that sums the two other metrics
   metric_query {
     id          = "total_visible"
-    expression  = "production_visible + production_background_visible + production_registration_visible"
+    expression  = "production_visible + production_background_visible + production_registration_visible + production_import_datacite_doi + production_import_other_doi"
     label       = "Total visible messages"
     return_data = "true"
+  }
+
+  metric_query {
+    id = "production_import_datacite_doi"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_import"
+      }
+    }
+  }
+
+  metric_query {
+    id = "production_import_other_doi"
+
+    metric {
+      metric_name = "ApproximateNumberOfMessagesVisible"
+      namespace   = "AWS/SQS"
+      period      = "120"
+      stat        = "Maximum"
+
+      dimensions = {
+        QueueName = "production_import_other_doi"
+      }
+    }
   }
 
   metric_query {


### PR DESCRIPTION
## Purpose
This change aims to improve the scaling of the queue worker by incorporating new SQS queues into the CloudWatch metric alarms that trigger scaling events. Previously, only certain queues were monitored, potentially leading to under-provisioning when message volumes in other queues increased.

## Approach
The existing `aws_cloudwatch_metric_alarm` resources for both scaling up and scaling down have been modified to include two new SQS queues: `production_import` and `production_import_other_doi`. The `total_visible` metric expression has been updated to sum the `ApproximateNumberOfMessagesVisible` from these new queues, along with the existing monitored queues.

### Key Modifications

*   **Updated `total_visible` metric expression:** Both `queue_worker_scale_up_alarm` and `queue_worker_scale_down_alarm` now include `production_import_datacite_doi` and `production_import_other_doi` in their `total_visible` expression.
*   **Added new metric queries:** Specific metric queries have been added for `production_import_datacite_doi` and `production_import_other_doi` to fetch their `ApproximateNumberOfMessagesVisible` from AWS/SQS.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
