### PR TITLE
change ports to 8080 as AWS doesn't allow binding to port 80

### DIFF
--- a/stage/services/metadata-completeness-api/main.tf
+++ b/stage/services/metadata-completeness-api/main.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_service" "metadata-completeness-api-stage" {
   load_balancer {
     target_group_arn = aws_lb_target_group.metadata-completeness-api-stage.id
     container_name   = "metadata-completeness-api-stage"
-    container_port   = "80"
+    container_port   = "8080"
   }
 
   service_registries {

--- a/stage/services/metadata-completeness-api/metadata-completeness-api.json
+++ b/stage/services/metadata-completeness-api/metadata-completeness-api.json
@@ -8,8 +8,8 @@
         "networkMode": "awsvpc",
         "portMappings": [
             {
-                "containerPort": 80,
-                "hostPort": 80
+                "containerPort": 8080,
+                "hostPort": 8080
             }
         ],
         "logConfiguration": {


### PR DESCRIPTION
## Purpose
Change ports to 8080 as AWS doesn't allow binding to port 80

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
