### PR TITLE
Add ROR analysis S3 bucket variable to staging Client API config

### DIFF
--- a/stage/services/client-api/client-api.json
+++ b/stage/services/client-api/client-api.json
@@ -212,6 +212,10 @@
       {
         "name": "ENABLE_PASSENGER_METRICS",
         "value": "True"
+      },
+      { 
+        "name": "ROR_ANALYSIS_S3_BUCKET",
+        "value": "${ror_analysis_s3_bucket}"
       }
     ]
   }

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -81,6 +81,7 @@ resource "aws_ecs_task_definition" "client-api-stage" {
       monthly_datafile_access_role            = var.monthly_datafile_access_role
       enrichments_ingestion_files_bucket_name = var.enrichments_ingestion_files_bucket_name
       disable_facets_by_default               = var.disable_facets_by_default
+      ror_analysis_s3_bucket                  = var.ror_analysis_s3_bucket
   })
 }
 

--- a/stage/services/client-api/queue-worker.json
+++ b/stage/services/client-api/queue-worker.json
@@ -200,6 +200,10 @@
       {
         "name": "ENRICHMENTS_INGESTION_FILES_BUCKET_NAME",
         "value": "${enrichments_ingestion_files_bucket_name}"
+      },
+      { 
+        "name": "ROR_ANALYSIS_S3_BUCKET",
+        "value": "${ror_analysis_s3_bucket}"
       }
     ]
   }

--- a/stage/services/client-api/queue-worker.tf
+++ b/stage/services/client-api/queue-worker.tf
@@ -70,6 +70,7 @@ resource "aws_ecs_task_definition" "queue-worker-stage" {
       passenger_max_pool_size                 = var.passenger_max_pool_size
       passenger_min_instances                 = var.passenger_min_instances
       enrichments_ingestion_files_bucket_name = var.enrichments_ingestion_files_bucket_name
+      ror_analysis_s3_bucket                  = var.ror_analysis_s3_bucket
   })
 }
 

--- a/stage/services/client-api/var.tf
+++ b/stage/services/client-api/var.tf
@@ -111,3 +111,5 @@ variable "enrichments_ingestion_files_bucket_name" {
 variable "disable_facets_by_default" {
   default = "false"
 }
+
+variable "ror_analysis_s3_bucket" { }


### PR DESCRIPTION
## Purpose

The purpose of this PR is to introduce a new configuration variable for the ROR (Research Organization Registry) analysis S3 bucket within the Client API service for the staging environment.

## Approach

The change adds a new variable definition to the Terraform configuration to allow the application to reference an S3 bucket dedicated to ROR analysis data.

### Key Modifications

- **Terraform Configuration**: Added the `ror_analysis_s3_bucket` variable to `stage/services/client-api/var.tf`.

### Important Technical Details

- The variable is currently declared without a default value, meaning it must be supplied via a `.tfvars` file, environment variable, or CI/CD pipeline configuration during deployment.
- This change sets the stage for integrating ROR analysis features into the Client API.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.