### PR TITLE
New autoscaling setup - staging and production

### DIFF
--- a/prod-eu-west/services/client-api/main.tf
+++ b/prod-eu-west/services/client-api/main.tf
@@ -192,6 +192,86 @@ resource "aws_cloudwatch_metric_alarm" "client-api_cpu_scale_down" {
 //   alarm_actions     = [aws_appautoscaling_policy.client-api_scale_down.arn]
 // }
 
+# New Scaling Configuration
+## Worker Utilisation
+resource "aws_appautoscaling_policy" "client-api-worker_util_scale_up" {
+  name               = "client-api-worker-util-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.client-api.resource_id
+  scalable_dimension = aws_appautoscaling_target.client-api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.client-api.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 120 # TODO: Evaluate this during alarm testing
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "client-api-worker_util_scale_down" {
+  name               = "client-api-worker-util-scale-down"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.client-api.resource_id
+  scalable_dimension = aws_appautoscaling_target.client-api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.client-api.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 300 # TODO: Evaluate this during alarm testing
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+}
+
+## Queue Size
+resource "aws_appautoscaling_policy" "client-api-emergency_scale_up" {
+  name               = "client-api-queue-size-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.client-api.resource_id
+  scalable_dimension = aws_appautoscaling_target.client-api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.client-api.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 120 # TODO: Evaluate this during alarm testing
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 2
+    }
+  }
+}
+
+## P95 Response Time
+resource "aws_appautoscaling_policy" "client-api_response_time_scale_up" {
+  name               = "client-api-response-time-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.client-api.resource_id
+  scalable_dimension = aws_appautoscaling_target.client-api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.client-api.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 300 # TODO: Evaluate this during alarm testing
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
 resource "aws_cloudwatch_log_group" "client-api" {
   name = "/ecs/client-api"
 }

--- a/prod-eu-west/services/client-api/main.tf
+++ b/prod-eu-west/services/client-api/main.tf
@@ -193,7 +193,14 @@ resource "aws_cloudwatch_metric_alarm" "client-api_cpu_scale_down" {
 // }
 
 # New Scaling Configuration
-## Worker Utilisation
+
+## Scaling Alarms SNS Topic
+resource "aws_sns_topic" "client-api-scaling-alarms" {
+  name = "client-api-scaling-alarms"
+}
+
+## Scaling Policy Actions
+### Worker Utilisation
 resource "aws_appautoscaling_policy" "client-api-worker_util_scale_up" {
   name               = "client-api-worker-util-scale-up"
   policy_type        = "StepScaling"
@@ -232,7 +239,7 @@ resource "aws_appautoscaling_policy" "client-api-worker_util_scale_down" {
   }
 }
 
-## Queue Size
+### Queue Size
 resource "aws_appautoscaling_policy" "client-api-emergency_scale_up" {
   name               = "client-api-queue-size-scale-up"
   policy_type        = "StepScaling"
@@ -252,8 +259,8 @@ resource "aws_appautoscaling_policy" "client-api-emergency_scale_up" {
   }
 }
 
-## P95 Response Time
-resource "aws_appautoscaling_policy" "client-api_response_time_scale_up" {
+### P95 Response Time
+resource "aws_appautoscaling_policy" "client-api-response_time_scale_up" {
   name               = "client-api-response-time-scale-up"
   policy_type        = "StepScaling"
   resource_id        = aws_appautoscaling_target.client-api.resource_id
@@ -270,6 +277,109 @@ resource "aws_appautoscaling_policy" "client-api_response_time_scale_up" {
       scaling_adjustment          = 1
     }
   }
+}
+
+## CloudWatch Metrics Alarms
+### Worker utilisation
+resource "aws_cloudwatch_metric_alarm" "client-api-worker_util_scale_up" {
+  alarm_name          = "client-api-worker-utilisation-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
+  metric_name         = "PassengerWorkerUtilisation"
+  namespace           = "Custom/LupoPassenger"
+  period              = "60" # TODO: Evaluate this during alarm testing
+  statistic           = "Average"
+  threshold           = 75  # TODO: Update this number based on traffic analysis
+
+  dimensions = {
+    Service = "client-api"
+  }
+
+  alarm_description = "Scale up client-api when average worker utilisation is high"
+  alarm_actions     = [
+    #aws_appautoscaling_policy.client-api-worker_util_scale_up.arn,
+    aws_sns_topic.client-api-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.client-api-scaling-alarms.arn]
+  #actions_enabled   = false  # TODO: Remove this once alarms are verified
+}
+
+resource "aws_cloudwatch_metric_alarm" "client-api-worker_util_scale_down" {
+  alarm_name          = "client-api-worker-utilisation-low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
+  metric_name         = "PassengerWorkerUtilisation"
+  namespace           = "Custom/LupoPassenger"
+  period              = "300" # TODO: Evaluate this during alarm testing
+  statistic           = "Maximum"
+  threshold           = 35  # TODO: Update this number based on traffic analysis
+
+  dimensions = {
+    Service = "client-api"
+  }
+
+  alarm_description = "Scale down client-api when max worker utilisation has lowered"
+  alarm_actions     = [
+    #aws_appautoscaling_policy.client-api-worker_util_scale_down.arn,
+    aws_sns_topic.client-api-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.client-api-scaling-alarms.arn]
+  #actions_enabled   = false # TODO: Remove this once alarms are verified
+}
+
+## Queue Size
+resource "aws_cloudwatch_metric_alarm" "client-api-queue_size_scale_up" {
+  alarm_name          = "client-api-queue-size-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2" # TODO: Evaluate this during alarm testing
+  metric_name         = "PassengerRequestQueue"
+  namespace           = "Custom/LupoPassenger"
+  period              = "60" # TODO: Evaluate this during alarm testing
+  statistic           = "Maximum"
+  threshold           = 1
+
+  dimensions = {
+    Service = "client-api"
+  }
+
+  alarm_description = "Emergency scale up: requests are queuing in client-api"
+  alarm_actions     = [
+    #aws_appautoscaling_policy.client-api-emergency_scale_up.arn,
+    aws_sns_topic.client-api-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.client-api-scaling-alarms.arn]
+  #actions_enabled = false # TODO: Remove this once alarms are verified
+}
+
+resource "aws_cloudwatch_metric_alarm" "client-api-response_time_scale_up" {
+  alarm_name          = "client-api-response-time-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
+  threshold           = 1 # TODO: Update this number based on traffic analysis
+
+  metric_query {
+    id          = "target_response_time"
+    return_data = true
+
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = "120" # TODO: Evaluate this during alarm testing
+      stat        = "p95"
+
+      dimensions = {
+        TargetGroup = aws_lb_target_group.client-api.arn_suffix
+      }
+    }
+  }
+
+  alarm_description = "Safety net: scale up client-api when P95 response time exceeds 1s"
+  alarm_actions     = [
+    #aws_appautoscaling_policy.client-api-response_time_scale_up.arn,
+    aws_sns_topic.client-api-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.client-api-scaling-alarms.arn]
+  #actions_enabled = false # TODO: Remove this once alarms are verified
 }
 
 resource "aws_cloudwatch_log_group" "client-api" {

--- a/prod-eu-west/services/client-api/member.tf
+++ b/prod-eu-west/services/client-api/member.tf
@@ -157,6 +157,92 @@ resource "aws_cloudwatch_metric_alarm" "member-api_cpu_scale_down" {
 //   alarm_actions     = [aws_appautoscaling_policy.member-api_scale_down.arn]
 // }
 
+# New Scaling Configuration
+## Scaling Alarms SNS Topic
+resource "aws_sns_topic" "member-api-scaling-alarms" {
+  name = "member-api-scaling-alarms"
+}
+
+## Scaling Policy Actions
+### Worker Utilisation
+resource "aws_appautoscaling_policy" "member-api-worker_util_scale_up" {
+  name               = "member-api-worker-util-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.member-api.resource_id
+  scalable_dimension = aws_appautoscaling_target.member-api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.member-api.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 120 # TODO: Evaluate this during alarm testing
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "member-api-worker_util_scale_down" {
+  name               = "member-api-worker-util-scale-down"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.member-api.resource_id
+  scalable_dimension = aws_appautoscaling_target.member-api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.member-api.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 300 # TODO: Evaluate this during alarm testing
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+}
+
+### Queue Size
+resource "aws_appautoscaling_policy" "member-api-emergency_scale_up" {
+  name               = "member-api-queue-size-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.member-api.resource_id
+  scalable_dimension = aws_appautoscaling_target.member-api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.member-api.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 120 # TODO: Evaluate this during alarm testing
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 2
+    }
+  }
+}
+
+### P95 Response Time
+resource "aws_appautoscaling_policy" "member-api-response_time_scale_up" {
+  name               = "member-api-response-time-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.member-api.resource_id
+  scalable_dimension = aws_appautoscaling_target.member-api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.member-api.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 300 # TODO: Evaluate this during alarm testing
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
 resource "aws_cloudwatch_log_group" "member-api" {
   name = "/ecs/member-api"
 }

--- a/prod-eu-west/services/client-api/member.tf
+++ b/prod-eu-west/services/client-api/member.tf
@@ -243,6 +243,109 @@ resource "aws_appautoscaling_policy" "member-api-response_time_scale_up" {
   }
 }
 
+## CloudWatch Metrics Alarms
+### Worker utilisation
+resource "aws_cloudwatch_metric_alarm" "member-api-worker_util_scale_up" {
+  alarm_name          = "member-api-worker-utilisation-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
+  metric_name         = "PassengerWorkerUtilisation"
+  namespace           = "Custom/LupoPassenger"
+  period              = "60" # TODO: Evaluate this during alarm testing
+  statistic           = "Average"
+  threshold           = 75  # TODO: Update this number based on traffic analysis
+
+  dimensions = {
+    Service = "member-api"
+  }
+
+  alarm_description = "Scale up member-api when average worker utilisation is high"
+  alarm_actions     = [
+    #aws_appautoscaling_policy.member-api-worker_util_scale_up.arn,
+    aws_sns_topic.member-api-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.member-api-scaling-alarms.arn]
+  #actions_enabled   = false  # TODO: Remove this once alarms are verified
+}
+
+resource "aws_cloudwatch_metric_alarm" "member-api-worker_util_scale_down" {
+  alarm_name          = "member-api-worker-utilisation-low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
+  metric_name         = "PassengerWorkerUtilisation"
+  namespace           = "Custom/LupoPassenger"
+  period              = "300" # TODO: Evaluate this during alarm testing
+  statistic           = "Maximum"
+  threshold           = 35  # TODO: Update this number based on traffic analysis
+
+  dimensions = {
+    Service = "member-api"
+  }
+
+  alarm_description = "Scale down member-api when max worker utilisation has lowered"
+  alarm_actions     = [
+    #aws_appautoscaling_policy.member-api-worker_util_scale_down.arn,
+    aws_sns_topic.member-api-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.member-api-scaling-alarms.arn]
+  #actions_enabled   = false # TODO: Remove this once alarms are verified
+}
+
+## Queue Size
+resource "aws_cloudwatch_metric_alarm" "member-api-queue_size_scale_up" {
+  alarm_name          = "member-api-queue-size-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2" # TODO: Evaluate this during alarm testing
+  metric_name         = "PassengerRequestQueue"
+  namespace           = "Custom/LupoPassenger"
+  period              = "60" # TODO: Evaluate this during alarm testing
+  statistic           = "Maximum"
+  threshold           = 1
+
+  dimensions = {
+    Service = "member-api"
+  }
+
+  alarm_description = "Emergency scale up: requests are queuing in member-api"
+  alarm_actions     = [
+    #aws_appautoscaling_policy.member-api-emergency_scale_up.arn,
+    aws_sns_topic.member-api-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.member-api-scaling-alarms.arn]
+  #actions_enabled = false # TODO: Remove this once alarms are verified
+}
+
+resource "aws_cloudwatch_metric_alarm" "member-api-response_time_scale_up" {
+  alarm_name          = "member-api-response-time-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
+  threshold           = 1 # TODO: Update this number based on traffic analysis
+
+  metric_query {
+    id          = "target_response_time"
+    return_data = true
+
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = "120" # TODO: Evaluate this during alarm testing
+      stat        = "p95"
+
+      dimensions = {
+        TargetGroup = aws_lb_target_group.member-api.arn_suffix
+      }
+    }
+  }
+
+  alarm_description = "Safety net: scale up member-api when P95 response time exceeds 1s"
+  alarm_actions     = [
+    #aws_appautoscaling_policy.member-api-response_time_scale_up.arn,
+    aws_sns_topic.member-api-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.member-api-scaling-alarms.arn]
+  #actions_enabled = false # TODO: Remove this once alarms are verified
+}
+
 resource "aws_cloudwatch_log_group" "member-api" {
   name = "/ecs/member-api"
 }

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -227,6 +227,28 @@ resource "aws_appautoscaling_policy" "client-api-stage_scale_down" {
   }
 }
 
+## Queue Size
+resource "aws_appautoscaling_policy" "client-api-stage_emergency_scale_up" {
+  name               = "client-api-stage-queue-depth-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.client-api-stage.resource_id
+  scalable_dimension = aws_appautoscaling_target.client-api-stage.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.client-api-stage.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 120
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 2
+    }
+  }
+}
+
+
+
 # CloudWatch Metrics Alarms
 ## Worker utilisation
 resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_up" {

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -177,3 +177,14 @@ resource "aws_s3_bucket" "metadata" {
     Name       = "Metadata storage"
   }
 }
+
+# Scaling Policy Actions
+## Autoscale Target
+resource "aws_appautoscaling_target" "client-api-stage" {
+  max_capacity       = 4
+  min_capacity       = 1
+  resource_id        = "service/stage/${aws_ecs_service.client-api-stage.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -229,7 +229,7 @@ resource "aws_appautoscaling_policy" "client-api-stage_scale_down" {
 
 ## Queue Size
 resource "aws_appautoscaling_policy" "client-api-stage_emergency_scale_up" {
-  name               = "client-api-stage-queue-depth-scale-up"
+  name               = "client-api-stage-queue-size-scale-up"
   policy_type        = "StepScaling"
   resource_id        = aws_appautoscaling_target.client-api-stage.resource_id
   scalable_dimension = aws_appautoscaling_target.client-api-stage.scalable_dimension
@@ -287,4 +287,24 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_down"
   alarm_description = "Scale down client-api.stage when max worker utilisation has lowered"
   alarm_actions     = [aws_appautoscaling_policy.client-api-stage_scale_down.arn]
   actions_enabled   = false # TODO: Remove this once alarms are verified
+}
+
+## Queue Size
+resource "aws_cloudwatch_metric_alarm" "client-api-stage_queue_size_scale_up" {
+  alarm_name          = "client-api-stage-queue-size-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "PassengerRequestQueue"
+  namespace           = "Custom/LupoPassenger"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = 1
+
+  dimensions = {
+    Service = "client-api.stage"
+  }
+
+  alarm_description = "Emergency scale up: requests are queuing in client-api.stage"
+  alarm_actions     = [aws_appautoscaling_policy.client-api-stage_emergency_scale_up.arn]
+  actions_enabled = false # TODO: Remove this once alarms are verified
 }

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -247,7 +247,25 @@ resource "aws_appautoscaling_policy" "client-api-stage_emergency_scale_up" {
   }
 }
 
+## P95 Response Time
+resource "aws_appautoscaling_policy" "client-api-stage_response_time_scale_up" {
+  name               = "client-api-stage-response-time-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.client-api-stage.resource_id
+  scalable_dimension = aws_appautoscaling_target.client-api-stage.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.client-api-stage.service_namespace
 
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 300
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
 
 # CloudWatch Metrics Alarms
 ## Worker utilisation

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -290,11 +290,11 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_up" {
 
   alarm_description = "Scale up client-api.stage when average worker utilisation is high"
   alarm_actions     = [
-    aws_appautoscaling_policy.client-api-stage_scale_up.arn,
+    #aws_appautoscaling_policy.client-api-stage_scale_up.arn,
     aws_sns_topic.client-api-stage-scaling-alarms.arn
   ]
   ok_actions = [aws_sns_topic.client-api-stage-scaling-alarms.arn]
-  actions_enabled   = false  # TODO: Remove this once alarms are verified
+  #actions_enabled   = false  # TODO: Remove this once alarms are verified
 }
 
 resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_down" {
@@ -313,11 +313,11 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_down"
 
   alarm_description = "Scale down client-api.stage when max worker utilisation has lowered"
   alarm_actions     = [
-    aws_appautoscaling_policy.client-api-stage_scale_down.arn,
+    #aws_appautoscaling_policy.client-api-stage_scale_down.arn,
     aws_sns_topic.client-api-stage-scaling-alarms.arn
   ]
   ok_actions = [aws_sns_topic.client-api-stage-scaling-alarms.arn]
-  actions_enabled   = false # TODO: Remove this once alarms are verified
+  #actions_enabled   = false # TODO: Remove this once alarms are verified
 }
 
 ## Queue Size
@@ -337,11 +337,11 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_queue_size_scale_up" {
 
   alarm_description = "Emergency scale up: requests are queuing in client-api.stage"
   alarm_actions     = [
-    aws_appautoscaling_policy.client-api-stage_emergency_scale_up.arn,
+    #aws_appautoscaling_policy.client-api-stage_emergency_scale_up.arn,
     aws_sns_topic.client-api-stage-scaling-alarms.arn
   ]
   ok_actions = [aws_sns_topic.client-api-stage-scaling-alarms.arn]
-  actions_enabled = false # TODO: Remove this once alarms are verified
+  #actions_enabled = false # TODO: Remove this once alarms are verified
 }
 
 resource "aws_cloudwatch_metric_alarm" "client-api-stage_response_time_scale_up" {
@@ -368,9 +368,9 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_response_time_scale_up"
 
   alarm_description = "Safety net: scale up client-api when P95 response time exceeds 1s"
   alarm_actions     = [
-    aws_appautoscaling_policy.client-api-stage_response_time_scale_up.arn,
+    #aws_appautoscaling_policy.client-api-stage_response_time_scale_up.arn,
     aws_sns_topic.client-api-stage-scaling-alarms.arn
   ]
   ok_actions = [aws_sns_topic.client-api-stage-scaling-alarms.arn]
-  actions_enabled = false # TODO: Remove this once alarms are verified
+  #actions_enabled = false # TODO: Remove this once alarms are verified
 }

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -178,6 +178,11 @@ resource "aws_s3_bucket" "metadata" {
   }
 }
 
+# Scaling alarms SNS topic
+resource "aws_sns_topic" "client-api-stage-scaling-alarms" {
+  name = "client-api-stage-scaling-alarms"
+}
+
 # Scaling Policy Actions
 ## Autoscale Target
 resource "aws_appautoscaling_target" "client-api-stage" {

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -198,7 +198,7 @@ resource "aws_appautoscaling_policy" "client-api-stage_scale_up" {
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
-    cooldown                = 120
+    cooldown                = 120 # TODO: Evaluate this during alarm testing
     metric_aggregation_type = "Average"
 
     step_adjustment {
@@ -217,7 +217,7 @@ resource "aws_appautoscaling_policy" "client-api-stage_scale_down" {
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
-    cooldown                = 300
+    cooldown                = 300 # TODO: Evaluate this during alarm testing
     metric_aggregation_type = "Maximum"
 
     step_adjustment {
@@ -237,7 +237,7 @@ resource "aws_appautoscaling_policy" "client-api-stage_emergency_scale_up" {
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
-    cooldown                = 120
+    cooldown                = 120 # TODO: Evaluate this during alarm testing
     metric_aggregation_type = "Maximum"
 
     step_adjustment {
@@ -257,7 +257,7 @@ resource "aws_appautoscaling_policy" "client-api-stage_response_time_scale_up" {
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
-    cooldown                = 300
+    cooldown                = 300 # TODO: Evaluate this during alarm testing
     metric_aggregation_type = "Average"
 
     step_adjustment {
@@ -272,10 +272,10 @@ resource "aws_appautoscaling_policy" "client-api-stage_response_time_scale_up" {
 resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_up" {
   alarm_name          = "client-api-stage-worker-utilisation-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
   metric_name         = "PassengerWorkerUtilisation"
   namespace           = "Custom/LupoPassenger"
-  period              = "60"
+  period              = "60" # TODO: Evaluate this during alarm testing
   statistic           = "Average"
   threshold           = 75  # TODO: Update this number based on traffic analysis
 
@@ -291,10 +291,10 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_up" {
 resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_down" {
   alarm_name          = "client-api-stage-worker-utilisation-low"
   comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "3"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
   metric_name         = "PassengerWorkerUtilisation"
   namespace           = "Custom/LupoPassenger"
-  period              = "300"
+  period              = "300" # TODO: Evaluate this during alarm testing
   statistic           = "Maximum"
   threshold           = 35  # TODO: Update this number based on traffic analysis
 
@@ -311,10 +311,10 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_down"
 resource "aws_cloudwatch_metric_alarm" "client-api-stage_queue_size_scale_up" {
   alarm_name          = "client-api-stage-queue-size-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = "2" # TODO: Evaluate this during alarm testing
   metric_name         = "PassengerRequestQueue"
   namespace           = "Custom/LupoPassenger"
-  period              = "60"
+  period              = "60" # TODO: Evaluate this during alarm testing
   statistic           = "Maximum"
   threshold           = 1
 
@@ -330,7 +330,7 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_queue_size_scale_up" {
 resource "aws_cloudwatch_metric_alarm" "client-api-stage_response_time_scale_up" {
   alarm_name          = "client-api-stage-response-time-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
+  evaluation_periods  = "3" # TODO: Evaluate this during alarm testing
   threshold           = 1 # TODO: Update this number based on traffic analysis
 
   metric_query {
@@ -340,7 +340,7 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_response_time_scale_up"
     metric {
       metric_name = "TargetResponseTime"
       namespace   = "AWS/ApplicationELB"
-      period      = "120"
+      period      = "120" # TODO: Evaluate this during alarm testing
       stat        = "p95"
 
       dimensions = {

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -188,3 +188,43 @@ resource "aws_appautoscaling_target" "client-api-stage" {
   service_namespace  = "ecs"
 }
 
+## Worker Utilisation
+resource "aws_appautoscaling_policy" "client-api-stage_scale_up" {
+  name               = "client-api-stage-worker-util-scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.client-api-stage.resource_id
+  scalable_dimension = aws_appautoscaling_target.client-api-stage.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.client-api-stage.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 120
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "client-api-stage_scale_down" {
+  name               = "client-api-stage-worker-util-scale-down"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.client-api-stage.resource_id
+  scalable_dimension = aws_appautoscaling_target.client-api-stage.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.client-api-stage.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 300
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+}
+
+

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -289,7 +289,11 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_up" {
   }
 
   alarm_description = "Scale up client-api.stage when average worker utilisation is high"
-  alarm_actions     = [aws_appautoscaling_policy.client-api-stage_scale_up.arn]
+  alarm_actions     = [
+    aws_appautoscaling_policy.client-api-stage_scale_up.arn,
+    aws_sns_topic.client-api-stage-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.client-api-stage-scaling-alarms.arn]
   actions_enabled   = false  # TODO: Remove this once alarms are verified
 }
 
@@ -308,7 +312,11 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_down"
   }
 
   alarm_description = "Scale down client-api.stage when max worker utilisation has lowered"
-  alarm_actions     = [aws_appautoscaling_policy.client-api-stage_scale_down.arn]
+  alarm_actions     = [
+    aws_appautoscaling_policy.client-api-stage_scale_down.arn,
+    aws_sns_topic.client-api-stage-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.client-api-stage-scaling-alarms.arn]
   actions_enabled   = false # TODO: Remove this once alarms are verified
 }
 
@@ -328,7 +336,11 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_queue_size_scale_up" {
   }
 
   alarm_description = "Emergency scale up: requests are queuing in client-api.stage"
-  alarm_actions     = [aws_appautoscaling_policy.client-api-stage_emergency_scale_up.arn]
+  alarm_actions     = [
+    aws_appautoscaling_policy.client-api-stage_emergency_scale_up.arn,
+    aws_sns_topic.client-api-stage-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.client-api-stage-scaling-alarms.arn]
   actions_enabled = false # TODO: Remove this once alarms are verified
 }
 
@@ -355,6 +367,10 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_response_time_scale_up"
   }
 
   alarm_description = "Safety net: scale up client-api when P95 response time exceeds 1s"
-  alarm_actions     = [aws_appautoscaling_policy.client-api-stage_response_time_scale_up.arn]
+  alarm_actions     = [
+    aws_appautoscaling_policy.client-api-stage_response_time_scale_up.arn,
+    aws_sns_topic.client-api-stage-scaling-alarms.arn
+  ]
+  ok_actions = [aws_sns_topic.client-api-stage-scaling-alarms.arn]
   actions_enabled = false # TODO: Remove this once alarms are verified
 }

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -227,4 +227,42 @@ resource "aws_appautoscaling_policy" "client-api-stage_scale_down" {
   }
 }
 
+# CloudWatch Metrics Alarms
+## Worker utilisation
+resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_up" {
+  alarm_name          = "client-api-stage-worker-utilisation-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "PassengerWorkerUtilisation"
+  namespace           = "Custom/LupoPassenger"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 75  # TODO: Update this number based on traffic analysis
 
+  dimensions = {
+    Service = "client-api.stage"
+  }
+
+  alarm_description = "Scale up client-api.stage when average worker utilisation is high"
+  alarm_actions     = [aws_appautoscaling_policy.client-api-stage_scale_up.arn]
+  actions_enabled   = false  # TODO: Remove this once alarms are verified
+}
+
+resource "aws_cloudwatch_metric_alarm" "client-api-stage_worker_util_scale_down" {
+  alarm_name          = "client-api-stage-worker-utilisation-low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "PassengerWorkerUtilisation"
+  namespace           = "Custom/LupoPassenger"
+  period              = "300"
+  statistic           = "Maximum"
+  threshold           = 35  # TODO: Update this number based on traffic analysis
+
+  dimensions = {
+    Service = "client-api.stage"
+  }
+
+  alarm_description = "Scale down client-api.stage when max worker utilisation has lowered"
+  alarm_actions     = [aws_appautoscaling_policy.client-api-stage_scale_down.arn]
+  actions_enabled   = false # TODO: Remove this once alarms are verified
+}

--- a/stage/services/client-api/main.tf
+++ b/stage/services/client-api/main.tf
@@ -326,3 +326,30 @@ resource "aws_cloudwatch_metric_alarm" "client-api-stage_queue_size_scale_up" {
   alarm_actions     = [aws_appautoscaling_policy.client-api-stage_emergency_scale_up.arn]
   actions_enabled = false # TODO: Remove this once alarms are verified
 }
+
+resource "aws_cloudwatch_metric_alarm" "client-api-stage_response_time_scale_up" {
+  alarm_name          = "client-api-stage-response-time-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  threshold           = 1 # TODO: Update this number based on traffic analysis
+
+  metric_query {
+    id          = "target_response_time"
+    return_data = true
+
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = "120"
+      stat        = "p95"
+
+      dimensions = {
+        TargetGroup = aws_lb_target_group.client-api-stage.arn_suffix
+      }
+    }
+  }
+
+  alarm_description = "Safety net: scale up client-api when P95 response time exceeds 1s"
+  alarm_actions     = [aws_appautoscaling_policy.client-api-stage_response_time_scale_up.arn]
+  actions_enabled = false # TODO: Remove this once alarms are verified
+}


### PR DESCRIPTION
## Purpose
This PR implements the new autoscaling configuration defined in the [REST API Scaling - Assessment and Planning document](https://docs.google.com/document/d/1BJVNkyHcrC78T0p-YXKnXmO7-EpBwrlkborVEjRnWIE/edit?usp=sharing).

Currently the functionality of this code amounts to triggering alarms and pushing status updates to an SNS topic to be used for Slack integration. None of the current scaling setup is yet replaced. See the document for the implementation plan and rough timeline.

closes: https://github.com/datacite/product-backlog/issues/716, https://github.com/datacite/product-backlog/issues/719

## Approach
<!--- _How does this change address the problem?_ -->

- Adds configuration for each of the new scaling events
- Adds alarms to trigger the scaling events
- Adds an SNS topic for each service which will receive notifications of alarm status changes

NB: Two very important things about this PR:
1) Currently the new scaling actions are intentionally **DISABLED** in the alarm actions, so they will never fire automatically. At this stage we are not replacing the current setup, just preparing. The only action taken when each alarm fires is to publish to the SNS topic.
2) The numbers for all configurations are subject to revision following the traffic analysis work (see the planning doc for info). Numbers that may be changed have a `TODO` comment indicating that they are not final.


#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
