### PR TITLE
Add ROR analysis S3 bucket configuration to Client API services

### DIFF
--- a/prod-eu-west/services/client-api/client-api.json
+++ b/prod-eu-west/services/client-api/client-api.json
@@ -201,6 +201,10 @@
       {
         "name": "ENABLE_PASSENGER_METRICS",
         "value": "True"
+      },
+      { 
+        "name": "ROR_ANALYSIS_S3_BUCKET",
+        "value": "${ror_analysis_s3_bucket}"
       }
     ]
   }

--- a/prod-eu-west/services/client-api/graphql.json
+++ b/prod-eu-west/services/client-api/graphql.json
@@ -172,6 +172,10 @@
       {
         "name": "REDLOY_UNIQUE_ID",
         "value": "5e74ce71-bcb9-4379-8727-8a652683e181"
+      },
+      { 
+        "name": "ROR_ANALYSIS_S3_BUCKET",
+        "value": "${ror_analysis_s3_bucket}"
       }
     ]
   }

--- a/prod-eu-west/services/client-api/graphql.tf
+++ b/prod-eu-west/services/client-api/graphql.tf
@@ -161,6 +161,7 @@ resource "aws_ecs_task_definition" "graphql" {
       metadata_storage_bucket_name      = var.metadata_storage_bucket_name
       passenger_max_pool_size           = var.passenger_max_pool_size
       passenger_min_instances           = var.passenger_min_instances
+      ror_analysis_s3_bucket            = var.ror_analysis_s3_bucket
   })
 }
 

--- a/prod-eu-west/services/client-api/main.tf
+++ b/prod-eu-west/services/client-api/main.tf
@@ -241,6 +241,7 @@ resource "aws_ecs_task_definition" "client-api" {
       monthly_datafile_access_role            = var.monthly_datafile_access_role
       enrichments_ingestion_files_bucket_name = var.enrichments_ingestion_files_bucket_name
       disable_facets_by_default               = var.disable_facets_by_default
+      ror_analysis_s3_bucket                  = var.ror_analysis_s3_bucket
   })
 }
 

--- a/prod-eu-west/services/client-api/member-api.json
+++ b/prod-eu-west/services/client-api/member-api.json
@@ -188,6 +188,10 @@
       {
         "name": "ENABLE_PASSENGER_METRICS",
         "value": "True"
+      },
+      { 
+        "name": "ROR_ANALYSIS_S3_BUCKET",
+        "value": "${ror_analysis_s3_bucket}"
       }
     ]
   }

--- a/prod-eu-west/services/client-api/member.tf
+++ b/prod-eu-west/services/client-api/member.tf
@@ -205,6 +205,7 @@ resource "aws_ecs_task_definition" "member-api" {
       monthly_datafile_bucket           = var.monthly_datafile_bucket
       monthly_datafile_access_role      = var.monthly_datafile_access_role
       disable_facets_by_default         = var.disable_facets_by_default
+      ror_analysis_s3_bucket            = var.ror_analysis_s3_bucket
   })
 }
 

--- a/prod-eu-west/services/client-api/queue-worker.json
+++ b/prod-eu-west/services/client-api/queue-worker.json
@@ -176,6 +176,10 @@
       {
         "name": "REDLOY_UNIQUE_ID",
         "value": "5e74ce71-bcb9-4379-8727-8a652683e181"
+      },
+      { 
+        "name": "ROR_ANALYSIS_S3_BUCKET",
+        "value": "${ror_analysis_s3_bucket}"
       }
     ]
   }

--- a/prod-eu-west/services/client-api/queue-worker.tf
+++ b/prod-eu-west/services/client-api/queue-worker.tf
@@ -71,6 +71,7 @@ resource "aws_ecs_task_definition" "queue-worker" {
       passenger_max_pool_size                 = var.passenger_max_pool_size
       passenger_min_instances                 = var.passenger_min_instances
       enrichments_ingestion_files_bucket_name = var.enrichments_ingestion_files_bucket_name
+      ror_analysis_s3_bucket                  = var.ror_analysis_s3_bucket
   })
 }
 

--- a/prod-eu-west/services/client-api/var.tf
+++ b/prod-eu-west/services/client-api/var.tf
@@ -105,3 +105,5 @@ variable "enrichments_ingestion_files_bucket_name" {
 variable "disable_facets_by_default" {
   default = "false"
 }
+
+variable "ror_analysis_s3_bucket" { }


### PR DESCRIPTION
## Purpose

This PR introduces a new configuration variable for the ROR (Research Organization Registry) analysis S3 bucket across the production Client API services. This change ensures that the application has access to the necessary S3 bucket resource for data analysis or storage related to ROR.

## Approach

The change involves adding a new variable `ror_analysis_s3_bucket` to the infrastructure configuration and injecting it into the environment templates for all relevant ECS task definitions within the `client-api` service suite.

### Key Modifications

- **Variable Definition**: Added `ror_analysis_s3_bucket` to `var.tf` to allow the value to be passed from the environment configuration.
- **Task Definitions**: Updated the following ECS task definitions to include the new variable in their container definitions:
    - `graphql.tf` (GraphQL service)
    - `main.tf` (Main Client API service)
    - `member.tf` (Member API service)
    - `queue-worker.tf` (Background Queue Worker)

### Important Technical Details

- The variable is passed into the `aws_ecs_task_definition` resources via the `template_file` or direct string interpolation (depending on the module structure), making it available as an environment variable within the running containers.
- This change is currently applied to the `prod-eu-west` region.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.