### PR TITLE
Add lb to dimensions for the response time alarms in production

### DIFF
--- a/prod-eu-west/services/client-api/main.tf
+++ b/prod-eu-west/services/client-api/main.tf
@@ -369,6 +369,7 @@ resource "aws_cloudwatch_metric_alarm" "client-api-response_time_scale_up" {
 
       dimensions = {
         TargetGroup = aws_lb_target_group.client-api.arn_suffix
+        LoadBalancer = data.aws_lb.default.arn_suffix
       }
     }
   }

--- a/prod-eu-west/services/client-api/main.tf
+++ b/prod-eu-west/services/client-api/main.tf
@@ -373,6 +373,7 @@ resource "aws_cloudwatch_metric_alarm" "client-api-response_time_scale_up" {
       }
     }
   }
+  treat_missing_data = "notBreaching"
 
   alarm_description = "Safety net: scale up client-api when P95 response time exceeds 1s"
   alarm_actions     = [

--- a/prod-eu-west/services/client-api/member.tf
+++ b/prod-eu-west/services/client-api/member.tf
@@ -333,6 +333,7 @@ resource "aws_cloudwatch_metric_alarm" "member-api-response_time_scale_up" {
 
       dimensions = {
         TargetGroup = aws_lb_target_group.member-api.arn_suffix
+        LoadBalancer = data.aws_lb.default.arn_suffix
       }
     }
   }

--- a/prod-eu-west/services/client-api/member.tf
+++ b/prod-eu-west/services/client-api/member.tf
@@ -337,6 +337,7 @@ resource "aws_cloudwatch_metric_alarm" "member-api-response_time_scale_up" {
       }
     }
   }
+  treat_missing_data = "notBreaching"
 
   alarm_description = "Safety net: scale up member-api when P95 response time exceeds 1s"
   alarm_actions     = [


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
The new alarms for ResponseTime were not picking up data correctly because they require the specific ELB to be explicitly provided as a dimension in addition to the target group (even though the target group already belongs to that LB :shrug: )

I've already made and tested the same change in staging: https://github.com/datacite/mastino/commit/ddb70be0965adee613dfd5b8876c8f6318411c38

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
