### PR TITLE
Add a stage-fb ecs task for API

### DIFF
--- a/modules/ecs-app/main.tf
+++ b/modules/ecs-app/main.tf
@@ -1,0 +1,96 @@
+locals {
+  full_app_name = "${var.app_name}-${var.env}"
+  discovery_name = "${var.app_name}.${var.env}"
+  log_group_name = "/ecs/${local.full_app_name}"
+  task_family    = local.full_app_name
+}
+
+data "aws_ecs_cluster" "ecs_cluster" {
+  cluster_name = var.env
+}
+
+data "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecsTaskExecutionRole"
+}
+
+data "aws_security_group" "datacite-private" {
+  id = var.security_group_id
+}
+
+data "aws_subnet" "datacite-private" {
+  id = var.subnet_datacite-private_id
+}
+
+data "aws_subnet" "datacite-alt" {
+  id = var.subnet_datacite-alt_id
+}
+
+
+resource "aws_cloudwatch_log_group" "log_group" {
+  name = local.log_group_name
+}
+
+resource "aws_ecs_service" "ecs-service" {
+  name            = local.full_app_name
+  cluster         = data.aws_ecs_cluster.ecs_cluster.id
+  launch_type     = "FARGATE"
+  task_definition = aws_ecs_task_definition.ecs_task_definition.arn
+  desired_count   = var.task_desired_count
+
+  network_configuration {
+    security_groups = [data.aws_security_group.datacite-private.id]
+    subnets = [
+      data.aws_subnet.datacite-private.id,
+      data.aws_subnet.datacite-alt.id
+    ]
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.service_discovery.arn
+  }
+
+  # Optional load balancer attached
+
+  dynamic "load_balancer" {
+    for_each = var.load_balancer_config
+    
+    iterator = lb
+    
+    content {
+      target_group_arn = lb.value.target_group_arn
+      container_name   = local.full_app_name
+      container_port   = lb.value.container_port
+    }
+  }
+
+}
+
+resource "aws_ecs_task_definition" "ecs_task_definition" {
+  family = local.task_family
+  execution_role_arn = data.aws_iam_role.ecs_task_execution_role.arn
+  network_mode = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu = var.task_cpu
+  memory = var.task_memory
+
+  container_definitions = var.container_definition_json
+}
+
+
+resource "aws_service_discovery_service" "service_discovery" {
+  name = local.discovery_name
+
+  health_check_custom_config {
+    failure_threshold = 3
+  }
+
+  dns_config {
+    namespace_id = var.namespace_id
+
+    dns_records {
+      ttl = 300
+      type = "A"
+    }
+  }
+}
+

--- a/modules/ecs-app/var.tf
+++ b/modules/ecs-app/var.tf
@@ -1,0 +1,69 @@
+
+variable "app_name" {
+  description = "Name of the application (e.g., client-api)"
+  type        = string
+}
+
+variable "env" {
+  description = "Environment name (e.g., stage, test, prod)"
+  type        = string
+}
+
+variable "task_desired_count" {
+  description = "Number of tasks to run"
+  type        = number
+  default     = 1
+}
+
+variable "task_cpu" {
+  description = "CPU units for Fargate"
+  type        = string
+}
+
+variable "task_memory" {
+  description = "Memory in MiB for Fargate"
+  type        = string
+}
+
+variable "container_definition_json" {
+  type        = string
+  description = "A string containing a JSON-encoded array of container definitions"
+}
+
+variable "container_port" {
+  description = "Port the container listens on"
+  type        = number
+  default     = 80
+}
+
+variable "vpc_id" {
+  description = "VPC ID where resources are deployed"
+  type        = string
+}
+
+variable "security_group_id" {
+    type = string
+}
+
+variable "subnet_datacite-private_id" {
+    type = string
+}
+
+variable "subnet_datacite-alt_id" {
+    type = string
+}
+
+variable "namespace_id" {
+  description = "ID of the Service Discovery Namespace"
+  type        = string
+}
+
+variable "load_balancer_config" {
+  description = "Optional load balancer configuration. If empty, no load balancer is attached."
+  type        = list(object({
+    target_group_arn = string
+    container_port   = number
+  }))
+  default     = []
+}
+

--- a/stage/services/client-api/_lupo.auto.tfvars
+++ b/stage/services/client-api/_lupo.auto.tfvars
@@ -1,4 +1,5 @@
 lupo_tags = {
   sha = "9725719d2df5936ea58aaae8f3efe96654bbfe15"
   version = "ks-rails-8-upgrade"
+  fb_version = "master"
 }

--- a/stage/services/client-api/_lupo.auto.tfvars.tmpl
+++ b/stage/services/client-api/_lupo.auto.tfvars.tmpl
@@ -1,4 +1,5 @@
 lupo_tags = {
   sha = "{{ .Env.GIT_SHA }}"
   version = "{{ .Env.GIT_TAG }}"
+  fb_version "{{ .Env.GIT_TAG }}"
 }

--- a/stage/services/client-api/stage-fb.tf
+++ b/stage/services/client-api/stage-fb.tf
@@ -1,0 +1,144 @@
+locals {
+  app_name = "client-api-fb"
+  fb_dns_name = "api.stage-fb.datacite.org"
+}
+
+module "fb-app" {
+    source = "../../../modules/ecs-app"
+
+    app_name = local.app_name
+    env = "stage"
+    vpc_id = var.vpc_id
+    task_desired_count = 1
+    security_group_id = var.security_group_id
+    subnet_datacite-private_id = var.subnet_datacite-private_id
+    subnet_datacite-alt_id = var.subnet_datacite-alt_id
+    task_cpu = "2028"
+    task_memory = "4096"
+    container_definition_json = data.template_file.stage-fb-task.rendered
+    namespace_id = var.namespace_id
+    load_balancer_config = [
+      {
+        container_port = 80
+        target_group_arn = aws_lb_target_group.client-api-stage-fb.arn
+      }
+    ]
+}
+
+data "template_file" "stage-fb-task" {
+  template = "${file("client-api.json")}"
+
+  vars = {
+      re3data_url                             = var.re3data_url
+      bracco_url                              = var.bracco_url
+      public_key                              = var.public_key
+      jwt_public_key                          = var.jwt_public_key
+      jwt_private_key                         = var.jwt_private_key
+      session_encrypted_cookie_salt           = var.session_encrypted_cookie_salt
+      mysql_user                              = var.mysql_user
+      mysql_password                          = var.mysql_password
+      mysql_database                          = var.mysql_database
+      mysql_host                              = var.mysql_host
+      es_name                                 = var.es_name
+      es_host                                 = var.es_host
+      es_scheme                               = var.es_scheme
+      es_port                                 = var.es_port
+      es_prefix                               = var.es_prefix
+      elastic_password                        = var.elastic_password
+      handle_url                              = var.handle_url
+      handle_username                         = var.handle_username
+      handle_password                         = var.handle_password
+      admin_username                          = var.admin_username
+      admin_password                          = var.admin_password
+      access_key                              = var.api_aws_access_key
+      secret_key                              = var.api_aws_secret_key
+      region                                  = var.region
+      s3_bucket                               = var.s3_bucket
+      sentry_dsn                              = var.sentry_dsn
+      mailgun_api_key                         = var.mailgun_api_key
+      memcache_servers                        = var.memcache_servers
+      jwt_blacklisted                         = var.jwt_blacklisted
+      slack_webhook_url                       = var.slack_webhook_url
+      version                                 = var.lupo_tags["fb_version"]
+      sha                                     = ""
+      exclude_prefixes_from_data_import       = var.exclude_prefixes_from_data_import
+      metadata_storage_bucket_name            = var.metadata_storage_bucket_name
+      passenger_max_pool_size                 = var.passenger_max_pool_size
+      passenger_min_instances                 = var.passenger_min_instances
+      monthly_datafile_bucket                 = var.monthly_datafile_bucket
+      monthly_datafile_access_role            = var.monthly_datafile_access_role
+      enrichments_ingestion_files_bucket_name = var.enrichments_ingestion_files_bucket_name
+      disable_facets_by_default               = var.disable_facets_by_default
+      ror_analysis_s3_bucket                  = var.ror_analysis_s3_bucket
+  }
+}
+
+resource "aws_lb_target_group" "client-api-stage-fb" {
+  name        = "client-api-stage-fb"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path     = "/heartbeat"
+    interval = 300
+    timeout  = 120
+  }
+}
+
+resource "aws_lb_listener_rule" "api-graphql-stage-fb" {
+  listener_arn = data.aws_lb_listener.stage.arn
+  priority     = 48
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.client-api-stage-fb.arn
+  }
+
+  condition {
+    host_header {
+      values = [local.fb_dns_name]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/client-api/graphql"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "api-stage-fb" {
+  listener_arn = data.aws_lb_listener.stage.arn
+  priority     = 54
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.client-api-stage-fb.arn
+  }
+
+  condition {
+    host_header {
+      values = [local.fb_dns_name]
+    }
+  }
+
+}
+
+resource "aws_route53_record" "api-stage-fb" {
+  zone_id = data.aws_route53_zone.production.zone_id
+  name    = "api.stage-fb.datacite.org"
+  type    = "CNAME"
+  ttl     = var.ttl
+  records = [data.aws_lb.stage.dns_name]
+}
+
+resource "aws_route53_record" "split-api-stage-fb" {
+  zone_id = data.aws_route53_zone.internal.zone_id
+  name    = "api.stage-fb.datacite.org"
+  type    = "CNAME"
+  ttl     = var.ttl
+  records = [data.aws_lb.stage.dns_name]
+}
+


### PR DESCRIPTION
## Purpose
On the main API we often need to be looking at both the main branch and also a feature branch.
Currently we switch the main container to a specific branch adhoc.

closes: _Add github issue that originated this PR_

## Approach
Adds a new specific container task that is based off a different container build.
The new endpoint would also be deployed at "api.stage-fb.datacite.org"

Note, all variables are atm the same, so there is no different database or opensearch, but this could change.

I also experimenting with using a module to define ECS Apps as a lot of our configuration is the same with minor variance, this is possibly part of goal to simplify all app definitions to use a module.

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
