### PR TITLE
Use a specific var for the feature branch

### DIFF
--- a/stage/services/client-api/_lupo.auto.tfvars
+++ b/stage/services/client-api/_lupo.auto.tfvars
@@ -1,5 +1,4 @@
 lupo_tags = {
   sha = "d591e6726761210f7ab96c85de1cd5b79dacd844"
   version = "add-enriched-doi-os-index"
-  fb_version = "<no value>"
 }

--- a/stage/services/client-api/_lupo.auto.tfvars.tmpl
+++ b/stage/services/client-api/_lupo.auto.tfvars.tmpl
@@ -1,5 +1,4 @@
 lupo_tags = {
   sha = "{{ .Env.GIT_SHA }}"
   version = "{{ .Env.GIT_TAG }}"
-  fb_version = "{{ .Env.FB_GIT_TAG }}"
 }

--- a/stage/services/client-api/stage-fb.tf
+++ b/stage/services/client-api/stage-fb.tf
@@ -60,7 +60,7 @@ data "template_file" "stage-fb-task" {
       memcache_servers                        = var.memcache_servers
       jwt_blacklisted                         = var.jwt_blacklisted
       slack_webhook_url                       = var.slack_webhook_url
-      version                                 = var.lupo_tags["fb_version"]
+      version                                 = var.fb_version
       sha                                     = ""
       exclude_prefixes_from_data_import       = var.exclude_prefixes_from_data_import
       metadata_storage_bucket_name            = var.metadata_storage_bucket_name

--- a/stage/services/client-api/var.tf
+++ b/stage/services/client-api/var.tf
@@ -13,6 +13,12 @@ variable "lupo_tags" {
   type = map(string)
 }
 
+variable "fb_version" {
+  type = string
+  description = "This is the name of the container image tag that you want to set the feature branch to use."
+  default = "master"
+}
+
 variable "lb_name" {
   default = "lb-stage"
 }


### PR DESCRIPTION
New Var for deployment.

## Purpose
This moves the varible used for the feature branch to a new custom tf var. 
This will need to be set explicitly.

## Approach
The problem with using the tfvars file which is our current approach means it's an all or nothing and it's hard to specifically setup different values while not interfering with the regular staging deployment.

Instead we'll just be explicit, if someone wants to deploy a feature branch they muse use terraform cloud to manage it.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
